### PR TITLE
New Rule 0021: Build actions should have a single task

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0018** Order using directives by type](rules/Proj0018.md)
 * [**Proj0019** Order using directives alphabetically](rules/Proj0019.md)
 * [**Proj0020** Item group should only contain nodes of a single type](rules/Proj0020.md)
+* [**Proj0021** Build actions should have a single task](rules/Proj0021.md)
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)
 * [**Proj0201** Define the project version explicitly](rules/Proj0201.md)
 * [**Proj0202** Define the project description explicitly](rules/Proj0202.md)

--- a/rules/Proj0021.md
+++ b/rules/Proj0021.md
@@ -1,0 +1,27 @@
+# Proj0021: Build actions should have a single task
+`<ItemGroup>` build taks nodes such as `<Compile>`, `<Content>`, `<EmbeddedResource>`,
+`<None>`, and `<AdditionalFiles` should only have on task. Assigning multiple
+tasks to a single node seperated by semicolons (`;`) leads to longer lines
+that are harder to read and maintain.
+
+## Non-compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <None Include="../common/LICENSE.md;README.md" />
+  </ItemGroup>
+  
+</Project>
+```
+
+## Compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <None Include="../common/LICENSE.md" />
+	<None Include="README.md" />
+  </ItemGroup>
+</Project>
+```

--- a/rules/Proj0021.md
+++ b/rules/Proj0021.md
@@ -21,7 +21,7 @@ that are harder to read and maintain.
 
   <ItemGroup>
     <None Include="../common/LICENSE.md" />
-	<None Include="README.md" />
+    <None Include="README.md" />
   </ItemGroup>
 </Project>
 ```


### PR DESCRIPTION
`<ItemGroup>` build taks nodes such as `<Compile>`, `<Content>`, `<EmbeddedResource>`, `<None>`, and `<AdditionalFiles` should only have on task. Assigning multiple tasks to a single node seperated by semicolons (`;`) leads to longer lines
that are harder to read and maintain.

[Related PR](https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/110)