### PR TITLE
New Rule Proj0022: Build action includes should exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0019** Order using directives alphabetically](rules/Proj0019.md)
 * [**Proj0020** Item group should only contain nodes of a single type](rules/Proj0020.md)
 * [**Proj0021** Build actions should have a single task](rules/Proj0021.md)
+* [**Proj0022** Build actions should have a single task](rules/Proj0022.md)
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)
 * [**Proj0201** Define the project version explicitly](rules/Proj0201.md)
 * [**Proj0202** Define the project description explicitly](rules/Proj0202.md)

--- a/rules/Proj0022.md
+++ b/rules/Proj0022.md
@@ -1,0 +1,28 @@
+# Proj0022: Build action includes should exist
+`<ItemGroup>` build taks nodes such as `<Compile>`, `<Content>`, `<EmbeddedResource>`,
+`<None>`, and `<AdditionalFiles` can define an `Include`. This include should 
+refer to one or multiple files.
+
+## Non-compliant
+When `README.md` does not exist.
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+  
+</Project>
+```
+
+## Compliant
+When `README.md` does exist.
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+
+</Project>
+```


### PR DESCRIPTION
Documentation for [PR 111](https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/111).