### PR TITLE
New Rule 1002: Use Microsoft's analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0600** Avoid generating packages on build if not packable](rules/Proj0600.md)
 * [**Proj1000** Use the .NET project file analyzers](rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
+* [**Proj1002** Use Microsoft's analyzers](rules/Proj1002.md)
 * [**Proj1003** Use Sonar analyzers](rules/Proj1003.md)
 * [**Proj1100** Avoid using Moq](rules/Proj1100.md)
 * [**Proj1200** Exclude private assets as project file dependency](rules/Proj1200.md)

--- a/rules/Proj1002.md
+++ b/rules/Proj1002.md
@@ -1,0 +1,20 @@
+# Proj1002: Use Microsoft's analyzers
+[microsoft](https://microsoft.com) has implemented multiple generic
+Roslyn static code analysis rules both for C# and Visual Basic. These rules
+allow you to produce safe, reliable and maintainable code by helping you find
+and correct bugs, vulnerabilities and code smells in your codebase. It is
+strongly advised to enable this rules on all your projects.
+
+See: [learn.microsoft.com/dotnet/fundamentals/code-analysis/overview](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/overview)
+
+## Compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+  </PropertyGroup>
+
+</Project>
+```

--- a/rules/Proj1002.md
+++ b/rules/Proj1002.md
@@ -1,9 +1,13 @@
 # Proj1002: Use Microsoft's analyzers
-[microsoft](https://microsoft.com) has implemented multiple generic
+[Microsoft](https://microsoft.com) has implemented multiple generic
 Roslyn static code analysis rules both for C# and Visual Basic. These rules
 allow you to produce safe, reliable and maintainable code by helping you find
 and correct bugs, vulnerabilities and code smells in your codebase. It is
-strongly advised to enable this rules on all your projects.
+strongly advised to enable these rules on all your projects.
+
+For .NET 5 and later, <EnableNETAnalyzers> is enabled by default. However,
+it is considered a good practice to explicitly enable it for later frameworks
+as well.
 
 See: [learn.microsoft.com/dotnet/fundamentals/code-analysis/overview](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/overview)
 

--- a/rules/Proj1003.md
+++ b/rules/Proj1003.md
@@ -3,7 +3,7 @@
 Roslyn static code analysis rules both for C# and Visual Basic. These rules
 allow you to produce safe, reliable and maintainable code by helping you find
 and correct bugs, vulnerabilities and code smells in your codebase. It is
-strongly advised to enable this rules on all your projects.
+strongly advised to enable these rules on all your projects.
 
 See: [https://github.com/SonarSource/sonar-dotnet](https://github.com/SonarSource/sonar-dotnet)
 


### PR DESCRIPTION
[microsoft](https://microsoft.com) has implemented multiple generic Roslyn static code analysis rules both for C# and Visual Basic. These rules allow you to produce safe, reliable and maintainable code by helping you find and correct bugs, vulnerabilities and code smells in your codebase. It is strongly advised to enable this rules on all your projects.

See: [learn.microsoft.com/dotnet/fundamentals/code-analysis/overview](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/overview)

## Compliant
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net8.0</TargetFramework>
    <EnableNETAnalyzers>true</EnableNETAnalyzers>
  </PropertyGroup>

</Project>
```
