### PR TITLE
New Rule 0023: Use forward slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0020** Item group should only contain nodes of a single type](rules/Proj0020.md)
 * [**Proj0021** Build actions should have a single task](rules/Proj0021.md)
 * [**Proj0022** Build actions should have a single task](rules/Proj0022.md)
+* [**Proj0023** Use forward slashes in paths](rules/Proj0023.md)
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)
 * [**Proj0201** Define the project version explicitly](rules/Proj0201.md)
 * [**Proj0202** Define the project description explicitly](rules/Proj0202.md)

--- a/rules/Proj0023.md
+++ b/rules/Proj0023.md
@@ -38,7 +38,7 @@ Windows. This is not true for backward slashes (`\`).
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Files\*" />
+    <None Remove="Files/*" />
   </ItemGroup>
 
 </Project>

--- a/rules/Proj0023.md
+++ b/rules/Proj0023.md
@@ -1,0 +1,45 @@
+# Proj0023: Use forward slashes in paths
+The use of forward slashes (`/`) is preferred as they work both for UNIX and
+Windows. This is not true for backward slashes (`\`).
+
+## Non-compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\props\simple.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\common\Code.cs" Link="Include\Code.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Files\*" />
+  </ItemGroup>
+
+</Project>
+```
+
+## Compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../props/simple.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" Link="Include/Code.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Files\*" />
+  </ItemGroup>
+
+</Project>
+```


### PR DESCRIPTION
# Proj0023: Use forward slashes in paths
The use of forward slashes (`/`) is preferred as they work both for UNIX and Windows. This is not true for backward slashes (`\`).

## Non-compliant
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <Import Project="..\props\simple.props" />
  
  <PropertyGroup>
    <TargetFramework>net8.0</TargetFramework>
  </PropertyGroup>

  <ItemGroup>
    <Compile Include="..\common\Code.cs" Link="Include\Code.cs" />
  </ItemGroup>

  <ItemGroup>
    <None Remove="Files\*" />
  </ItemGroup>

</Project>
```

## Compliant
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <Import Project="../props/simple.props" />
  
  <PropertyGroup>
    <TargetFramework>net8.0</TargetFramework>
  </PropertyGroup>

  <ItemGroup>
    <Compile Include="../common/Code.cs" Link="Include/Code.cs" />
  </ItemGroup>

  <ItemGroup>
    <None Remove="Files/*" />
  </ItemGroup>

</Project>
```
