### PR TITLE
Proj1101: Package references should have stable versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj1002** Use Microsoft's analyzers](rules/Proj1002.md)
 * [**Proj1003** Use Sonar analyzers](rules/Proj1003.md)
 * [**Proj1100** Avoid using Moq](rules/Proj1100.md)
+* [**Proj1101** Package references should have stable versions](rules/Proj1101.md)
 * [**Proj1200** Exclude private assets as project file dependency](rules/Proj1200.md)
 * [**Proj1700** Indent XML](rules/Proj1700.md)
 

--- a/rules/Proj1101.md
+++ b/rules/Proj1101.md
@@ -1,0 +1,36 @@
+﻿# Proj1101: Package references should have stable versions
+When building code that goes into production, your code should not rely on a
+nightly build ore other pre-release version of an (external) package. This rule
+reports on packages that are not conidered stable releases.
+
+Note that packages referenses that are a private asset for all output, are ignored.
+
+## Non-compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Hashing" Version="9.0.0-preview.7.24405.7" />
+  </ItemGroup>
+
+</Project>
+```
+
+## Compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Hashing" Version="9.0.0" />
+  </ItemGroup>
+
+</Project>
+```

--- a/rules/Proj1101.md
+++ b/rules/Proj1101.md
@@ -1,9 +1,9 @@
 ﻿# Proj1101: Package references should have stable versions
-When building code that goes into production, your code should not rely on a
-nightly build ore other pre-release version of an (external) package. This rule
-reports on packages that are not considered stable releases.
+Code that goes into production should not rely on a nightly build or a
+pre-release version of a package. This rule reports on packages that are not
+considered stable releases.
 
-Note that packages referenses that are a private asset for all output, are ignored.
+Note that packages references that are a private asset for all output, are ignored.
 
 ## Non-compliant
 ``` XML

--- a/rules/Proj1101.md
+++ b/rules/Proj1101.md
@@ -1,7 +1,7 @@
 ﻿# Proj1101: Package references should have stable versions
 When building code that goes into production, your code should not rely on a
 nightly build ore other pre-release version of an (external) package. This rule
-reports on packages that are not conidered stable releases.
+reports on packages that are not considered stable releases.
 
 Note that packages referenses that are a private asset for all output, are ignored.
 


### PR DESCRIPTION
When building code that goes into production, your code should not rely on a nightly build ore other pre-release version of an (external) package. This rule reports on packages that are not considered stable releases.