### PR TITLE
Proj0804: Use Version only with Central Package Management not enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0801** Include 'Directory.Packages.props'](rules/Proj0801.md)
 * [**Proj0802** Enable Central Package Management centrally](rules/Proj0802.md)
 * [**Proj0803** Use VersionOverride only with Central Package Management enabled](rules/Proj0803.md)
+* [**Proj0804** Use Version only with Central Package Management not enabled](rules/Proj0804.md)
 * [**Proj0805** Define version for PackageReference](rules/Proj0805.md)
 
 ### Analyzers

--- a/rules/Proj0804.md
+++ b/rules/Proj0804.md
@@ -20,10 +20,22 @@ unintentionally disabled.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Qowaiv" Version="7.0.4" />
+    <PackageReference Include="Qowaiv" VersionOverride="7.0.4" />
   </ItemGroup>
 
 </Project>
 ```
 
-Or disable CPM.
+or
+
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" />
+  </ItemGroup>
+
+</Project>
+```
+
+or disable CPM.

--- a/rules/Proj0804.md
+++ b/rules/Proj0804.md
@@ -1,0 +1,29 @@
+# Proj0804: Use Version only with Central Package Management not enabled
+When [Central Package Management](Proj0800.md) is enabled, the use of the
+`Version` property on a `<PackageReference>` has no effect. It is most
+likely an mistake; or `VersionOverride` was intended, or the CPM has been
+unintentionally disabled.
+
+## Non-compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="7.0.4" />
+  </ItemGroup>
+
+</Project>
+```
+
+## Compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="7.0.4" />
+  </ItemGroup>
+
+</Project>
+```
+
+Or disable CPM.


### PR DESCRIPTION
Documentation for https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/153.