### PR TITLE
Proj0807: Use Directory.Packages.props only for Central Package Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0804** Use Version only with Central Package Management not enabled](rules/Proj0804.md)
 * [**Proj0805** Define version for PackageReference](rules/Proj0805.md)
 * [**Proj0806** VersionOverride should change the version](rules/Proj0806.md)
+* [**Proj0807** Use Directory.Packages.props only for Central Package Management](rules/Proj0807.md)
 
 ### Analyzers
 * [**Proj1000** Use the .NET project file analyzers](rules/Proj1000.md)

--- a/rules/Proj0807.md
+++ b/rules/Proj0807.md
@@ -1,0 +1,67 @@
+# Proj0807: Use Directory.Packages.props only for Central Package Management
+When using [Central Package Management](Proj0800.md) the central `Directory.Packages.props`
+file should only contain settings that are related to CPM. Although it will
+work otherwise, it is counter-intuitive and recipe for disaster.
+
+## Non-compliant
+``` XML
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Qowaiv" Version="7.0.0" />
+    <PackageVersion Include="PolySharp" Version="1.14.1" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <GlobalPackageReference Include="System.Text.Json" Vesion="8.0.4" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="PolySharp" PrivateAssets="all" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <AdditionalFiles Include="Directory.Packages.props" Link="Properties/Directory.Packages.props" />
+    <AdditionalFiles Include="*.ts" />
+  </ItemGroup>
+
+</Project>
+
+```
+
+## Compliant
+``` XML
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Qowaiv" Version="7.0.0" />
+    <PackageVersion Include="PolySharp" Version="1.14.1" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <GlobalPackageReference Include="System.Text.Json" Vesion="8.0.4" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <AdditionalFiles Include="Directory.Packages.props" Link="Properties/Directory.Packages.props" />
+  </ItemGroup>
+
+</Project>
+
+```


### PR DESCRIPTION
Documentation that goes with https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/156.