### PR TITLE
Proj3000: Only use UTF-8 without BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj2004** Add invariant fallback values](rules/Proj2004.md)
 * [**Proj2100** Indent RESX](rules/Proj2100.md)
 
+## Generic
+* [**Proj3000** Only use UTF-8 without BOM](rules/Proj3000.md)
+
 ## Additional files
 To fully benefit from these analyzers it is recommended to add the project file
 (and imported projects/props) as additional files.

--- a/rules/Proj3000.md
+++ b/rules/Proj3000.md
@@ -18,7 +18,7 @@ The use of BOM for UTF-8 however, can be problematic:
    often hard to replace, (legacy) tools to break down.
 3. It is not possible to concatenate several files together (without changes)
    because each file now has a BOM at the beginning.
-4. Multiple standards (including CSS, JSON, YAML) explicitly disalow the use of
+4. Multiple standards (including CSS, JSON, YAML) explicitly disallow the use of
    UTF-8 BOM.
 
 Therefor, this rule will warn when a file is stored with an UTF-8 BOM.

--- a/rules/Proj3000.md
+++ b/rules/Proj3000.md
@@ -14,9 +14,8 @@ The use of BOM for UTF-8 however, can be problematic:
 
 1. Files that hold no text are no longer empty because they always contain the BOM.
 2. Files that hold text within the ASCII subset of UTF-8 are no longer
-   themselves ASCII because the BOM is not ASCII, which makes some existing
-   tools break down, and it can be impossible for users to replace such legacy
-   tools.
+   themselves ASCII because the BOM is not ASCII. This can cause existing,
+   often hard to replace, (legacy) tools to break down.
 3. It is not possible to concatenate several files together (without changes)
    because each file now has a BOM at the beginning.
 4. Multiple standards (including CSS, JSON, YAML) explicitly disalow the use of

--- a/rules/Proj3000.md
+++ b/rules/Proj3000.md
@@ -1,0 +1,25 @@
+# Proj3000: Only use UTF-8 without BOM
+The [byte-order mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark)
+is a particular usage of the special Unicode character code, whose appearance
+as a magic number at the start of a text stream can signal several things to a
+program reading the text.
+
+> [...] Use of a BOM is neither required nor recommended for UTF-8, but may be
+> encountered in contexts where UTF-8 data is converted from other encoding
+> forms that use a BOM or where the BOM is used as a UTF-8 signature. See the
+> “Byte Order Mark” subsection in Section 16.8, Specials, for more information.
+> [...]
+
+The use of BOM for UTF-8 however, can be problematic:
+
+1. Files that hold no text are no longer empty because they always contain the BOM.
+2. Files that hold text within the ASCII subset of UTF-8 are no longer
+   themselves ASCII because the BOM is not ASCII, which makes some existing
+   tools break down, and it can be impossible for users to replace such legacy
+   tools.
+3. It is not possible to concatenate several files together (without changes)
+   because each file now has a BOM at the beginning.
+4. Multiple standards (including CSS, JSON, YAML) explicitly disalow the use of
+   UTF-8 BOM.
+
+Therefor, this rule will warn when a file is stored with an UTF-8 BOM.


### PR DESCRIPTION
Documentation for this [PR](https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/210).