### PR TITLE
Proj0030: Use VB.NET specific properties only in when applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0026** Remove IncludeAssets when redundant](rules/Proj0026.md)
 * [**Proj0027** Override &lt;TargetFrameworks&gt; with &lt;TargetFrameworks&gt;](rules/Proj0027.md)
 * [**Proj0028** Define conditions on level 1](rules/Proj0028.md)
+* [**Proj0030** Use VB.NET specific properties only in when applicable](rules/Proj0030.md)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0026** Remove IncludeAssets when redundant](rules/Proj0026.md)
 * [**Proj0027** Override &lt;TargetFrameworks&gt; with &lt;TargetFrameworks&gt;](rules/Proj0027.md)
 * [**Proj0028** Define conditions on level 1](rules/Proj0028.md)
-* [**Proj0030** Use VB.NET specific properties only in when applicable](rules/Proj0030.md)
+* [**Proj0030** Use VB.NET specific properties only when applicable](rules/Proj0030.md)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)

--- a/rules/Proj0030.md
+++ b/rules/Proj0030.md
@@ -1,4 +1,4 @@
-# Proj0030: Use VB.NET specific properties only in when applicable
+# Proj0030: Use VB.NET specific properties only when applicable
 When building a VB.NET project, MS Build supports multiple VB.NET only
 properties to be set. For none VB.NET projects however, settings these
 properties does not make any sense.

--- a/rules/Proj0030.md
+++ b/rules/Proj0030.md
@@ -1,6 +1,6 @@
 # Proj0030: Use VB.NET specific properties only when applicable
 When building a VB.NET project, MS Build supports multiple VB.NET only
-properties to be set. For none VB.NET projects however, settings these
+properties to be set. For none VB.NET projects however, setting these
 properties does not make any sense.
 
 ## VB.NET only properties

--- a/rules/Proj0030.md
+++ b/rules/Proj0030.md
@@ -1,0 +1,14 @@
+# Proj0030: Use VB.NET specific properties only in when applicable
+When building a VB.NET project, MS Build supports multiple VB.NET only
+properties to be set. For none VB.NET projects however, settings these
+properties does not make any sense.
+
+## VB.NET only properties
+- FrameworkPathOverride
+- NoVBRuntimeReference
+- OptionExplicit
+- OptionInfer
+- OptionStrict
+- RemoveIntegerChecks
+- VbcToolPath
+- VbcVerbosity


### PR DESCRIPTION
Documentation for https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/223.