### PR TITLE
Proj0700: Avoid defining <Compile> items in SDK project

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0452** Test projects require Microsoft.NET.Test.Sdk](rules/Proj0452.md)
 * [**Proj0453** Using Microsoft.NET.Test.Sdk implies a test project](rules/Proj0453.md)
 
+## .NET Project File Analyzers SDK
+* [**Proj0700** Avoid defining &lt;Compile&gt; items in SDK project](rules/Proj0700.md)
+
 ### Central Package Management
 * [**Proj0800** Configure Central Package Management](rules/Proj0800.md)
 * [**Proj0801** Include 'Directory.Packages.props'](rules/Proj0801.md)

--- a/rules/Proj0700.md
+++ b/rules/Proj0700.md
@@ -1,5 +1,5 @@
 # Proj0700: Avoid defining <Compile> items in SDK project
-The .[net.csproj SDK project](../general/sdk.md) is a placeholder for
+The [.net.csproj SDK project](../general/sdk.md) is a placeholder for
 non-compiling files. Adding `<Compile>` items has no meaning, as the
 project has no (publically) accessable compilition artifacts.
 

--- a/rules/Proj0700.md
+++ b/rules/Proj0700.md
@@ -1,0 +1,28 @@
+# Proj0700: Avoid defining <Compile> items in SDK project
+The .[net.csproj SDK project](../general/sdk.md) is a placeholder for
+non-compiling files. Adding `<Compile>` items has no meaning, as the
+project has no (publically) accessable compilition artifacts.
+
+## Non-compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <Compile Include="Code.cs" />
+  </ItemGroup>
+  
+</Project>
+```
+
+## Compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <None Include="Code.cs" />
+	<Content Include="Code.cs" />
+	<AdditionalFiles Include="Code.cs" />
+  </ItemGroup>
+  
+</Project>
+```

--- a/rules/Proj0700.md
+++ b/rules/Proj0700.md
@@ -1,7 +1,7 @@
 # Proj0700: Avoid defining <Compile> items in SDK project
 The [.net.csproj SDK project](../general/sdk.md) is a placeholder for
 non-compiling files. Adding `<Compile>` items has no meaning, as the
-project has no (publically) accessable compilition artifacts.
+project has no (publically) accessable compilation artifacts.
 
 ## Non-compliant
 ``` XML


### PR DESCRIPTION
Documentation for a rule linked to https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/230