### PR TITLE
Change code snippet language names to be Rouge compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ to understand if the documented feature you want to use has been released.
 [![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/v/DotNetProjectFile.Analyzers)![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/dt/DotNetProjectFile.Analyzers)](https://www.nuget.org/packages/DotNetProjectFile.Analyzers/)
 
 To use the analyzers, you must include the analyzer package in your project file:
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -170,7 +170,7 @@ To fully benefit from these analyzers it is recommended to add the project file
 
 To add a project file:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -182,7 +182,7 @@ To add a project file:
 
 To add a props file:
 
-``` XML
+``` xml
 <Project>
 
   <ItemGroup>

--- a/general/configuration.md
+++ b/general/configuration.md
@@ -14,7 +14,7 @@ It is also possible to configure rules using a [Global AnalyzerConfig](https://l
 one of its (grand)parent directories. The following `.globalconfig` file will
 disable rule `Proj0010` and raise `Proj0011` to error level:
 
-``` INI
+``` ini
 is_global = true
 
 dotnet_diagnostic.Proj0010.severity = none  # Define the <OutputType> node explicitly.
@@ -25,7 +25,7 @@ dotnet_diagnostic.Proj0011.severity = error # Property <{0}> has been already de
 It is also possible to define project specific preferences as you would have done in
 an `.globalconfig` file, using `<GlobalAnalyzerConfigFiles>`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -37,7 +37,7 @@ an `.globalconfig` file, using `<GlobalAnalyzerConfigFiles>`:
 It is recommended to use the `.ini` extension for such a file, as it helps
 with syntax highlighting. A custom config file could look like this:
 
-``` INI
+``` ini
 is_global = false
 
 dotnet_diagnostic.Proj0002.severity = error # Upgrade legacy MS Build project files
@@ -50,7 +50,7 @@ tag inside your `.csproj` (or `.props`) file.
 
 An example of disabling rules `Proj0010` and `Proj0011` through the `.csproj` file:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
@@ -65,7 +65,7 @@ Adopted from C-style languages, it is possible to suppress
 individual violations and/or [false positives](https://en.wikipedia.org/wiki/False_positives_and_false_negatives).
 In a MS Build project file this would look like:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!-- #pragma warning disable Proj0008 -->

--- a/general/sdk.md
+++ b/general/sdk.md
@@ -9,7 +9,7 @@ So how does it work? At the root level of your solution (most likely the
 directory conting the [Git](https://en.wikipedia.org/wiki/Git) repo), you
  create a C# Project file with the name `.net.csproj`.
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -33,7 +33,7 @@ analyzed by the appropriate .NET Project File Analyzers.
 
 Those analyzers can be included with:
 
-``` XML
+``` xml
 <ItemGroup>
   <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" />
 </ItemGroup>

--- a/general/sonar-integration.md
+++ b/general/sonar-integration.md
@@ -26,7 +26,7 @@ SonarCloud will recognise it's warnings and pick them up, same as any warnings i
 code.
 
 For Example:
-``` XML
+``` xml
   <ItemGroup>
     <Content Include="*.??proj" CopyToOutputDirectory="Never"/>
     <Content Include="../../props/common.props" CopyToOutputDirectory="Never" Link="Properties/common.props"/>

--- a/rules/Proj0003.md
+++ b/rules/Proj0003.md
@@ -39,7 +39,7 @@ reducing using statements in your project can be easily achieved by defining
 namespaces globally in a file.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -51,7 +51,7 @@ namespaces globally in a file.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -61,7 +61,7 @@ namespaces globally in a file.
 </Project>
 ```
 
-``` C#
+``` csharp
 global using System;
 global using System.Collections.Generic;
 global using System.IO;

--- a/rules/Proj0004.md
+++ b/rules/Proj0004.md
@@ -6,7 +6,7 @@ issues that come with using any of the referenced packages.
 More information: https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -18,7 +18,7 @@ More information: https://learn.microsoft.com/en-us/nuget/concepts/auditing-pack
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0005.md
+++ b/rules/Proj0005.md
@@ -5,7 +5,7 @@ it is preferred to define `PrivateAssets`, `IncludeAssets`, and `PrivateAsssets`
 as XML attributes, instead of XML elements.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Label="Analyzers">
@@ -18,7 +18,7 @@ as XML attributes, instead of XML elements.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Label="Analyzers">

--- a/rules/Proj0006.md
+++ b/rules/Proj0006.md
@@ -8,7 +8,7 @@ See: https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Using%20Additiona
 ## Compliant
 For project files, it is advised to add  the additional file with `Visible="false"`
 as seeing it twice in the IDE is adding confusion.
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -20,7 +20,7 @@ as seeing it twice in the IDE is adding confusion.
 
 For properties, it is advised to add the additional file with a link to the
 _special_ properties folder, to simplify the access to the files.
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 

--- a/rules/Proj0007.md
+++ b/rules/Proj0007.md
@@ -2,7 +2,7 @@
 Empty nodes only add noise, as they contain no information.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup />
@@ -14,7 +14,7 @@ Empty nodes only add noise, as they contain no information.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/common.props" />

--- a/rules/Proj0008.md
+++ b/rules/Proj0008.md
@@ -4,7 +4,7 @@ IDE; allowing to show the folder while it does not contain a file relevant for
 the .NET project yet. This should only exist temporarily.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -15,7 +15,7 @@ the .NET project yet. This should only exist temporarily.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
 </Project>

--- a/rules/Proj0009.md
+++ b/rules/Proj0009.md
@@ -3,7 +3,7 @@ To prevent confusion, only use the `<TargetFrameworks>` node when there are
 multiple target frameworks. Otherwise use the `<TargetFramework>` node.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -14,7 +14,7 @@ multiple target frameworks. Otherwise use the `<TargetFramework>` node.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0010.md
+++ b/rules/Proj0010.md
@@ -3,7 +3,7 @@ To prevent confusion, explicitly define the `<OutputType>`
 node as `'Library'`, `'Exe'`, `'WinExe'` or `'Module'`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -14,7 +14,7 @@ node as `'Library'`, `'Exe'`, `'WinExe'` or `'Module'`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0011.md
+++ b/rules/Proj0011.md
@@ -3,7 +3,7 @@ As MS Build will only select one value of a property, defining a property twice
 is adding noise, if not a bug.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -20,7 +20,7 @@ is adding noise, if not a bug.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0013.md
+++ b/rules/Proj0013.md
@@ -5,7 +5,7 @@ used. Update are only allowed in different files.
 
 ## Non-compliant
 ### common.props
-``` XML
+``` xml
 <Project>
 
   <ItemGroup>
@@ -15,7 +15,7 @@ used. Update are only allowed in different files.
 </Project>
 ```
 ### project.csproj
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -29,7 +29,7 @@ used. Update are only allowed in different files.
 
 ## Compliant
 ### common.props
-``` XML
+``` xml
 <Project>
 
   <ItemGroup>
@@ -39,7 +39,7 @@ used. Update are only allowed in different files.
 </Project>
 ```
 ### project.csproj
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0014.md
+++ b/rules/Proj0014.md
@@ -2,7 +2,7 @@
 A `<ProjectReference>` should only be defined once per package.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -14,7 +14,7 @@ A `<ProjectReference>` should only be defined once per package.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0015.md
+++ b/rules/Proj0015.md
@@ -6,7 +6,7 @@ other criteria, consider grouping them in seperate
 `<ItemGroup>`s.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -18,7 +18,7 @@ other criteria, consider grouping them in seperate
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0016.md
+++ b/rules/Proj0016.md
@@ -6,7 +6,7 @@ other criteria, consider grouping them in seperate
 `<ItemGroup>`s.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -18,7 +18,7 @@ other criteria, consider grouping them in seperate
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0017.md
+++ b/rules/Proj0017.md
@@ -4,7 +4,7 @@ For more info
 [see](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/using-directive-errors?f1url=%3FappId%3Droslyn%26k%3Dk(CS8085)#restrictions-on-using-aliases).
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -15,7 +15,7 @@ For more info
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0018.md
+++ b/rules/Proj0018.md
@@ -4,7 +4,7 @@
 grouping them in seperate `<ItemGroup>`s.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -17,7 +17,7 @@ grouping them in seperate `<ItemGroup>`s.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0019.md
+++ b/rules/Proj0019.md
@@ -4,7 +4,7 @@ in order to make it more human readable. When ordering the references based on
 other criteria, consider grouping them in seperate `<ItemGroup>`s.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -16,7 +16,7 @@ other criteria, consider grouping them in seperate `<ItemGroup>`s.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0020.md
+++ b/rules/Proj0020.md
@@ -4,7 +4,7 @@ of different types in a single `<ItemGroup>` can become harder to read and
 maintain.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -17,7 +17,7 @@ maintain.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0021.md
+++ b/rules/Proj0021.md
@@ -5,7 +5,7 @@ tasks to a single node seperated by semicolons (`;`) leads to longer lines
 that are harder to read and maintain.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -16,7 +16,7 @@ that are harder to read and maintain.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0022.md
+++ b/rules/Proj0022.md
@@ -5,7 +5,7 @@ refer to one or multiple files.
 
 ## Non-compliant
 When `README.md` does not exist.
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -17,7 +17,7 @@ When `README.md` does not exist.
 
 ## Compliant
 When `README.md` does exist.
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0023.md
+++ b/rules/Proj0023.md
@@ -3,7 +3,7 @@ The use of forward slashes (`/`) is preferred as they work both for UNIX and
 Windows. This is not true for backward slashes (`\`).
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\props\simple.props" />
@@ -24,7 +24,7 @@ Windows. This is not true for backward slashes (`\`).
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../props/simple.props" />

--- a/rules/Proj0024.md
+++ b/rules/Proj0024.md
@@ -6,7 +6,7 @@ other criteria, consider grouping them in seperate
 `<ItemGroup>`s.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -18,7 +18,7 @@ other criteria, consider grouping them in seperate
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0025.md
+++ b/rules/Proj0025.md
@@ -8,7 +8,7 @@ Alternatively, you can download the converter yourself from [NuGet](https://www.
 For more info: [learn.microsoft.com])https://learn.microsoft.com/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2022#convert-an-existing-ruleset-file-to-editorconfig-file)
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -20,7 +20,7 @@ For more info: [learn.microsoft.com])https://learn.microsoft.com/visualstudio/co
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0026.md
+++ b/rules/Proj0026.md
@@ -5,7 +5,7 @@ is not really a point in specifying the `IncludeAssets`.
 More about controlling dependency assets can be read [here](https://learn.microsoft.com/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets).
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -24,7 +24,7 @@ More about controlling dependency assets can be read [here](https://learn.micros
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0027.md
+++ b/rules/Proj0027.md
@@ -6,7 +6,7 @@ must be used instead.
 
 ## Non-compliant
 ### common.props
-``` XML
+``` xml
 <Project>
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
@@ -15,7 +15,7 @@ must be used instead.
 ```
 
 ### my-project.csproj
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="common.props" />
@@ -29,7 +29,7 @@ must be used instead.
 
 ## Compliant
 ### common.props
-``` XML
+``` xml
 <Project>
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
@@ -38,7 +38,7 @@ must be used instead.
 ```
 
 ### my-project.csproj
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="common.props" />

--- a/rules/Proj0028.md
+++ b/rules/Proj0028.md
@@ -7,7 +7,7 @@ is automatically grouped. Note that [Choose/When](https://learn.microsoft.com/vi
 is ignored by this rule.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project>
   
   <PropertyGroup>
@@ -19,7 +19,7 @@ is ignored by this rule.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project>
   
   <PropertyGroup>

--- a/rules/Proj0031.md
+++ b/rules/Proj0031.md
@@ -5,7 +5,7 @@ root node (`<Project>`) and its child nodes (such as `<PropertyGroup>` and
 issues, however, it is preferred to use the same casing consistently.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../props/simple.props" />
@@ -26,7 +26,7 @@ issues, however, it is preferred to use the same casing consistently.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../props/simple.props" />

--- a/rules/Proj0032.md
+++ b/rules/Proj0032.md
@@ -12,7 +12,7 @@ can, this rule reports violations for all target frameworks, and
 also when used in combination with [System.Runtime.Serialization.Formatters](https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-migration-guide/compatibility-package).
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -24,7 +24,7 @@ also when used in combination with [System.Runtime.Serialization.Formatters](htt
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0033.md
+++ b/rules/Proj0033.md
@@ -4,7 +4,7 @@ This include should refer to exactly one file.
 
 ## Non-compliant
 When `../Benchmarks/Benchmarks.csproj` does not exist.
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -16,7 +16,7 @@ When `../Benchmarks/Benchmarks.csproj` does not exist.
 
 ## Compliant
 When `../Benchmarks/Benchmarks.csproj` does exist.
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0200.md
+++ b/rules/Proj0200.md
@@ -10,7 +10,7 @@ unintended creation of NuGet packages for projects that were not intended as
 such (test projects, etc.).
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -21,7 +21,7 @@ such (test projects, etc.).
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0201.md
+++ b/rules/Proj0201.md
@@ -4,7 +4,7 @@ explicitly define the `<Version>` node or disable package generation by
 defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -30,7 +30,7 @@ defining the `<IsPackable>` node with value `false`.
 
 Or use version prefix and suffix:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -45,7 +45,7 @@ Or use version prefix and suffix:
 
 Or use version prefix:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -59,7 +59,7 @@ Or use version prefix:
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0202.md
+++ b/rules/Proj0202.md
@@ -4,7 +4,7 @@ explicitly define the `<Description>` or `<PackageDescription>` node or disable
 package generation by defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ package generation by defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -30,7 +30,7 @@ package generation by defining the `<IsPackable>` node with value `false`.
 
 Or:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -44,7 +44,7 @@ Or:
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0203.md
+++ b/rules/Proj0203.md
@@ -4,7 +4,7 @@ explicitly define the `<Authors>` node or disable package generation by
 defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -30,7 +30,7 @@ defining the `<IsPackable>` node with value `false`.
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0204.md
+++ b/rules/Proj0204.md
@@ -4,7 +4,7 @@ explicitly define the `<PackageTags>` node or disable package generation by
 defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -30,7 +30,7 @@ defining the `<IsPackable>` node with value `false`.
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0205.md
+++ b/rules/Proj0205.md
@@ -4,7 +4,7 @@ explicitly define the `<RepositoryUrl>` node or disable package generation by
 defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -30,7 +30,7 @@ defining the `<IsPackable>` node with value `false`.
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0206.md
+++ b/rules/Proj0206.md
@@ -4,7 +4,7 @@ explicitly define the `<PackageProjectUrl>` node or disable package generation b
 defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -30,7 +30,7 @@ defining the `<IsPackable>` node with value `false`.
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0207.md
+++ b/rules/Proj0207.md
@@ -4,7 +4,7 @@ explicitly define the `<Copyright>` node or disable package generation by
 defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -30,7 +30,7 @@ defining the `<IsPackable>` node with value `false`.
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0208.md
+++ b/rules/Proj0208.md
@@ -4,7 +4,7 @@ explicitly define the `<PackageReleaseNotes>` node or disable package
 generation by defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ generation by defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -36,7 +36,7 @@ v1.0.0
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0209.md
+++ b/rules/Proj0209.md
@@ -4,7 +4,7 @@ explicitly define the `<PackageReadmeFile>` node or disable package generation
 by defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ by defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -34,7 +34,7 @@ by defining the `<IsPackable>` node with value `false`.
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0210.md
+++ b/rules/Proj0210.md
@@ -10,7 +10,7 @@ identifier. A full list can be found on [spdx.org](https://spdx.org/licenses/).
 Also see [licenses.nuget.org](https://licenses.nuget.org).
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -22,7 +22,7 @@ Also see [licenses.nuget.org](https://licenses.nuget.org).
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -36,7 +36,7 @@ Also see [licenses.nuget.org](https://licenses.nuget.org).
 
 Or:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -54,7 +54,7 @@ Or:
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0211.md
+++ b/rules/Proj0211.md
@@ -4,7 +4,7 @@ either the `<PackageLicenseExpression>` or the `<PackageLicenseFile>` node
 when referring to the license of a [NuGet package](../general/nuget-packages.md).
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ when referring to the license of a [NuGet package](../general/nuget-packages.md)
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -29,7 +29,7 @@ when referring to the license of a [NuGet package](../general/nuget-packages.md)
 
 Or:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -46,7 +46,7 @@ Or:
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0212.md
+++ b/rules/Proj0212.md
@@ -11,7 +11,7 @@ tools can not correctly handle the modern option. For maximum compatibility it
 is therefore recommended to define both.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -23,7 +23,7 @@ is therefore recommended to define both.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -41,7 +41,7 @@ is therefore recommended to define both.
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0213.md
+++ b/rules/Proj0213.md
@@ -11,7 +11,7 @@ tools can not correctly handle the modern option. For maximum compatibility it
 is therefore recommended to define both.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -23,7 +23,7 @@ is therefore recommended to define both.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -37,7 +37,7 @@ is therefore recommended to define both.
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0214.md
+++ b/rules/Proj0214.md
@@ -4,7 +4,7 @@ explicitly define the `<PackageID>` node or disable package generation by
 defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -30,7 +30,7 @@ defining the `<IsPackable>` node with value `false`.
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0216.md
+++ b/rules/Proj0216.md
@@ -4,7 +4,7 @@ explicitly define the `<ProductName>` node or disable package generation by
 defining the `<IsPackable>` node with value `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ defining the `<IsPackable>` node with value `false`.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -30,7 +30,7 @@ defining the `<IsPackable>` node with value `false`.
 
 Or disable packability:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0240.md
+++ b/rules/Proj0240.md
@@ -7,7 +7,7 @@ to enable package validation by defining the
 More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview).
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -18,7 +18,7 @@ More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fu
 </Project>
 ```
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -31,7 +31,7 @@ More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fu
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -43,7 +43,7 @@ More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fu
 </Project>
 ```
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0241.md
+++ b/rules/Proj0241.md
@@ -8,7 +8,7 @@ of the previous stable release.
 More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/baseline-version-validator).
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -21,7 +21,7 @@ More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fu
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -34,7 +34,7 @@ More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fu
 </Project>
 ```
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -46,7 +46,7 @@ More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fu
 </Project>
 ```
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0242.md
+++ b/rules/Proj0242.md
@@ -5,7 +5,7 @@ or any of it ancestor nodes. Doing so, NuGet's artifacts are only generated
 during a RELEASE (or other intendend) build mode.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -16,7 +16,7 @@ during a RELEASE (or other intendend) build mode.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/rules/Proj0243.md
+++ b/rules/Proj0243.md
@@ -4,7 +4,7 @@ a detailed list of all components and dependencies in a software project should
 be published with (NuGet) package.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -15,7 +15,7 @@ be published with (NuGet) package.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0244.md
+++ b/rules/Proj0244.md
@@ -10,7 +10,7 @@ This requires _either_ `<GenerateDocumentationFile>` to be set to `true`,
 _or_ `<DocumentationFile>` to be defined, while `<GenerateDocumentationFile>` is not explicitly set to `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -22,7 +22,7 @@ _or_ `<DocumentationFile>` to be defined, while `<GenerateDocumentationFile>` is
 
 Or:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -35,7 +35,7 @@ Or:
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -48,7 +48,7 @@ Or:
 
 Or:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -61,7 +61,7 @@ Or:
 
 Or:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0245.md
+++ b/rules/Proj0245.md
@@ -11,7 +11,7 @@ or `{VersionPrefix}` otherwise.
 ## Non-compliant
 Resulting in version `1.2.3`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -26,7 +26,7 @@ Resulting in version `1.2.3`:
 
 Or resulting in version `1.2.3`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -40,7 +40,7 @@ Or resulting in version `1.2.3`:
 
 Or resulting in version `1.2.3`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -56,7 +56,7 @@ Or resulting in version `1.2.3`:
 
 Resulting in version `1.2.3`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -69,7 +69,7 @@ Resulting in version `1.2.3`:
 
 Or resulting in version `2.0.0-preview001`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -82,7 +82,7 @@ Or resulting in version `2.0.0-preview001`:
 
 Or resulting in version `2.0.0-preview001`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -96,7 +96,7 @@ Or resulting in version `2.0.0-preview001`:
 
 Or resulting in version `2.0.0`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -109,7 +109,7 @@ Or resulting in version `2.0.0`:
 
 Or resulting in version `1.0.0-preview001`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0246.md
+++ b/rules/Proj0246.md
@@ -10,7 +10,7 @@ Therefore it is most likely an error to set a suffix version, while keeping the 
 ## Non-compliant
 Resulting in version `1.0.0-preview001`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -25,7 +25,7 @@ Resulting in version `1.0.0-preview001`:
 
 Resulting in version `1.2.3-preview001`:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0400.md
+++ b/rules/Proj0400.md
@@ -14,7 +14,7 @@ the publishable projects, even if they have
 `IsPublishable` set to `false`.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -25,7 +25,7 @@ the publishable projects, even if they have
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0450.md
+++ b/rules/Proj0450.md
@@ -3,7 +3,7 @@ Test projects should only be responsible for running tests. Hence if they do
 create a (NuGet) package, that is most likely unintended, and wrong.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -20,7 +20,7 @@ create a (NuGet) package, that is most likely unintended, and wrong.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0451.md
+++ b/rules/Proj0451.md
@@ -3,7 +3,7 @@ Test projects should only be responsible for running tests. Hence if they
 can be published, that is most likely unintended, and wrong.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -20,7 +20,7 @@ can be published, that is most likely unintended, and wrong.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0452.md
+++ b/rules/Proj0452.md
@@ -5,7 +5,7 @@ with the `dotnet test` command, the [SDK](https://github.com/microsoft/vstest)
 has to be included.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -17,7 +17,7 @@ has to be included.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0453.md
+++ b/rules/Proj0453.md
@@ -5,7 +5,7 @@ including the [SDK](https://github.com/microsoft/vstest) is done to run unit
 tests with the `dotnet test` command.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -20,7 +20,7 @@ tests with the `dotnet test` command.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0600.md
+++ b/rules/Proj0600.md
@@ -5,7 +5,7 @@ Removing the `<GeneratePackageOnBuild>`
 node will reduce noise.,
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -17,7 +17,7 @@ node will reduce noise.,
 </Project>
 ```
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -30,7 +30,7 @@ node will reduce noise.,
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -42,7 +42,7 @@ node will reduce noise.,
 </Project>
 ```
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -54,7 +54,7 @@ node will reduce noise.,
 </Project>
 ```
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -65,7 +65,7 @@ node will reduce noise.,
 </Project>
 ```
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -76,7 +76,7 @@ node will reduce noise.,
 </Project>
 ```
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj0700.md
+++ b/rules/Proj0700.md
@@ -4,7 +4,7 @@ non-compiling files. Adding `<Compile>` items has no meaning, as the
 project has no (publically) accessable compilation artifacts.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -15,7 +15,7 @@ project has no (publically) accessable compilation artifacts.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0800.md
+++ b/rules/Proj0800.md
@@ -9,7 +9,7 @@ this from the ease of a single location.
 Hence, this rules advises to enable Central Package Management by
 enabling it with in the `Directory.Packages.props` file:
 
-``` XML
+``` xml
 <Project>
 
  <PropertyGroup>
@@ -23,7 +23,7 @@ When a solution has only a tiny number of project files, and/or hardly any
 packages shared amongst these projects, CPM might be not worth the effort. In
 that case it is also fine to explicitly disable it in the project file:
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>

--- a/rules/Proj0803.md
+++ b/rules/Proj0803.md
@@ -5,7 +5,7 @@ likely an mistake; or `Version` was intended, or the CPM has been unintentionall
 disabled.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -16,7 +16,7 @@ disabled.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0804.md
+++ b/rules/Proj0804.md
@@ -5,7 +5,7 @@ likely an mistake; or `VersionOverride` was intended, or the CPM has been
 unintentionally disabled.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -16,7 +16,7 @@ unintentionally disabled.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -28,7 +28,7 @@ unintentionally disabled.
 
 or
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0805.md
+++ b/rules/Proj0805.md
@@ -6,7 +6,7 @@ properly resolve the package. This can be done by either using the
 [Central Package Management](Proj0800.md) is enabled.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -17,7 +17,7 @@ properly resolve the package. This can be done by either using the
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -29,7 +29,7 @@ properly resolve the package. This can be done by either using the
 
 Or
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0806.md
+++ b/rules/Proj0806.md
@@ -5,7 +5,7 @@ different version then already defined by the CPM. In that case, the
 `VersionOverride` should be removed.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -16,7 +16,7 @@ different version then already defined by the CPM. In that case, the
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj0807.md
+++ b/rules/Proj0807.md
@@ -4,7 +4,7 @@ file should only contain settings that are related to CPM. Although it will
 work otherwise, it is counter-intuitive and recipe for disaster.
 
 ## Non-compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
@@ -40,7 +40,7 @@ work otherwise, it is counter-intuitive and recipe for disaster.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 

--- a/rules/Proj1000.md
+++ b/rules/Proj1000.md
@@ -3,7 +3,7 @@ The purpose of this rule is detect the absence of the .NET project file analyzer
 This can be achieved by adding the analyzers to the [Directory.Build.targets](https://learn.microsoft.com/visualstudio/msbuild/customize-your-build#directorybuildprops-and-directorybuildtargets).
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Label="Analyzer">

--- a/rules/Proj1001.md
+++ b/rules/Proj1001.md
@@ -34,7 +34,7 @@ The following analyzers are known to be beneficial for some packages:
 | [ZeroFormatter.Analyzer](https://www.nuget.org/packages/ZeroFormatter.Analyzer)                                       | [ZeroFormatter](https://www.nuget.org/packages?q=ZeroFormatter)                                   | Any       |
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Label="Analyzers">

--- a/rules/Proj1002.md
+++ b/rules/Proj1002.md
@@ -12,7 +12,7 @@ as well.
 See: [learn.microsoft.com/dotnet/fundamentals/code-analysis/overview](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/overview)
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj1003.md
+++ b/rules/Proj1003.md
@@ -9,7 +9,7 @@ See: [https://github.com/SonarSource/sonar-dotnet](https://github.com/SonarSourc
 
 ## Compliant
 For C# projects:
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Label="Analyzers">
@@ -20,7 +20,7 @@ For C# projects:
 ```
 
 For VB.NET projects:
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Label="Analyzers">

--- a/rules/Proj1100.md
+++ b/rules/Proj1100.md
@@ -11,7 +11,7 @@ Therefore, usage is strongly discouraged.
 Further reading: [Reddit](https://www.reddit.com/r/dotnet/comments/15ljdcc/does_moq_in_its_latest_version_extract_and_send/)
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
@@ -23,7 +23,7 @@ Further reading: [Reddit](https://www.reddit.com/r/dotnet/comments/15ljdcc/does_
 
 ## Compliant
 The last safe version.
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>

--- a/rules/Proj1101.md
+++ b/rules/Proj1101.md
@@ -6,7 +6,7 @@ considered stable releases.
 Note that packages references that are a private asset for all output, are ignored.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -21,7 +21,7 @@ Note that packages references that are a private asset for all output, are ignor
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj1200.md
+++ b/rules/Proj1200.md
@@ -5,7 +5,7 @@ marking them in the project file as private asset it will not become a runtime
 dependency, that is linked to a package, or shipped when publishing it.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" />
@@ -14,7 +14,7 @@ dependency, that is linked to a package, or shipped when publishing it.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" />
@@ -24,7 +24,7 @@ dependency, that is linked to a package, or shipped when publishing it.
 
 or
 
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PackageReference Include="DotNetProjectFile.Analyzers" Version="*">

--- a/rules/Proj1700.md
+++ b/rules/Proj1700.md
@@ -10,7 +10,7 @@ project files is properly indented. For now, only indentation using 2 spaces
 is supported, as we do not support reading the `.editorconfig` yet.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
@@ -27,7 +27,7 @@ is supported, as we do not support reading the `.editorconfig` yet.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj1701.md
+++ b/rules/Proj1701.md
@@ -4,7 +4,7 @@ To improve readability, and prevent [XML escaping](https://en.wikipedia.org/wiki
 `<![CDATA[` and `]]>` around large texts.
 
 ## Non-compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -27,7 +27,7 @@ v1.0.0
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj1702.md
+++ b/rules/Proj1702.md
@@ -6,7 +6,7 @@ version, encoding and standalone. All of this is redunant for MS Build project
 files, and hence the XML declaration should be omitted.
 
 ## Non-compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
@@ -18,7 +18,7 @@ files, and hence the XML declaration should be omitted.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/rules/Proj2000.md
+++ b/rules/Proj2000.md
@@ -3,7 +3,7 @@ A resource file should be a valid RESX file; XML, with a resmimetype, writer,
 and reader header.
 
 ## Compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">

--- a/rules/Proj2001.md
+++ b/rules/Proj2001.md
@@ -2,7 +2,7 @@
 A resource file without `<data>` elements is of no use.
 
 ## Non-compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <root>
  
@@ -10,7 +10,7 @@ A resource file without `<data>` elements is of no use.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- ... -->

--- a/rules/Proj2002.md
+++ b/rules/Proj2002.md
@@ -3,7 +3,7 @@ To improve readability, and reduce the number of merge conflicts, the `<data>`
 elements should be sorted based on the `@name` attribute.
 
 ## Non-compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- ... -->
@@ -17,7 +17,7 @@ elements should be sorted based on the `@name` attribute.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- ... -->

--- a/rules/Proj2005.md
+++ b/rules/Proj2005.md
@@ -4,7 +4,7 @@ resources files. It is strongly recommended to escape that XML using either
 `<![CDATA[`/`]]>` or `&lt;`/`@gt;` escaping sequences.
 
 ## Non-compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <root>
  <data name="King" xml:space="preserve">
@@ -17,7 +17,7 @@ resources files. It is strongly recommended to escape that XML using either
 ```
 
 ## Compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <root>
  <data name="King" xml:space="preserve">

--- a/rules/Proj2100.md
+++ b/rules/Proj2100.md
@@ -10,7 +10,7 @@ project files is properly indented. For now, only indentation using 2 spaces
 is supported, as we do not support reading the `.editorconfig` yet.
 
 ## Non-compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
@@ -32,7 +32,7 @@ is supported, as we do not support reading the `.editorconfig` yet.
 ```
 
 ## Compliant
-``` XML
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <root>
 

--- a/rules/Proj4001.md
+++ b/rules/Proj4001.md
@@ -5,7 +5,7 @@ a structure and syntax comprising key–value pairs organized in sections.
 Section headers start with a `[` and end with a `]`.
 
 ## Non-compliant
-``` INI
+``` ini
 [Header1
 
 [Header2]]
@@ -16,7 +16,7 @@ Section headers start with a `[` and end with a `]`.
 ```
 
 ## Compliant
-``` INI
+``` ini
 [Header1]
 
 [Header2]

--- a/rules/Proj4002.md
+++ b/rules/Proj4002.md
@@ -5,7 +5,7 @@ a structure and syntax comprising key–value pairs organized in sections.
 Key-value pairs can either be separated by `=` or `:`.
 
 ## Non-compliant
-``` INI
+``` ini
 Key1 =
 
 Key2 == value
@@ -16,7 +16,7 @@ Key4 value
 ```
 
 ## Compliant
-``` INI
+``` ini
 Key1 = value
 
 Key2 = value

--- a/rules/Proj4010.md
+++ b/rules/Proj4010.md
@@ -5,7 +5,7 @@ a structure and syntax comprising key–value pairs organized in sections.
 Sections without any key-value pairs defined, however, have no meaning.
 
 ## Non-compliant
-``` INI
+``` ini
 root = true
 
 [*]
@@ -25,7 +25,7 @@ indent_size = 2
 ```
 
 ## Compliant
-``` INI
+``` ini
 root = true
 
 [*]

--- a/rules/Proj4050.md
+++ b/rules/Proj4050.md
@@ -8,7 +8,7 @@ matches the files the key-value pairs of the section apply to. Therefor,
 they must be valid [GLOB](https://spec.editorconfig.org/#glob-expressions)s.
 
 ## Non-compliant
-``` INI
+``` ini
 root = true
 
 [*]
@@ -23,7 +23,7 @@ indent_size = 4
 ```
 
 ## Compliant
-``` INI
+``` ini
 root = true
 
 [*]

--- a/rules/Proj4051.md
+++ b/rules/Proj4051.md
@@ -7,13 +7,13 @@ The specification states that `=` should be used as assignment character, not
 `:`. Multiple IDEs (including Visual Studio), however, do support the `:`.
 
 ## Non-compliant
-``` INI
+``` ini
 [*]
 end_of_line: crlf
 ```
 
 ## Compliant
-``` INI
+``` ini
 [*]
 end_of_line = crlf
 ```


### PR DESCRIPTION
Code snippet highlighter used by Jekyll (Rouge) only supports the following case-sensitive language names: https://github.com/rouge-ruby/rouge/blob/master/docs/Languages.md