### PR TITLE
Rewrite the purpose of Proj0502

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 ### Licensing
 * [**Proj0500** Only include packages with an explicitly defined license](rules/Proj0500.md)
 * [**Proj0501** Package only contains a deprecated license URL](rules/Proj0501.md)
-* [**Proj0502** Only include packages with a compliant license](rules/Proj0502.md)
+* [**Proj0502** Only include packages compliant with project license](rules/Proj0502.md)
 
 ### .NET Project File Analyzers SDK
 * [**Proj0700** Avoid defining &lt;Compile&gt; items in SDK project](rules/Proj0700.md)

--- a/rules/Proj0502.md
+++ b/rules/Proj0502.md
@@ -3,42 +3,26 @@ parent: Licensing
 ancestor: Rules
 ---
 
-# Proj0502: Only include packages with a compliant license
+# Proj0502: Only include packages compliant with project license
 Using a [NuGet](https://www.nuget.org) package implies that you
 and/or your company explicitly agree with the legally binding conditions of the
 license and the copyright of the owner of the package.
 
-By default, MIT and Apache-2.0 are allowed.
-
-This rule can detect used licenses in NuGet spec files, but can not be
-considered legal advice, nor is this documentation.
+If a third-party package license is not compliant with the license of the
+project, this rule will report the license violation.
 
 ## Configure
-You can specify which license (expressions) are allowed, using `<AllowedLicenses>`.
+You can specify a license (expression) as follows:
 
 ``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AllowedLicenses>MIT,MPL-1.1,Apache-2.0</AllowedLicenses>
+    <PackageLicenseExpression>MIT</AllowedLicenses>
   </PropertyGroup>
   
 </Project>
 ```
 
-For packages that do not come with a generic license (expression) such as MIT,
-it is possible to specify that these packages are allowed, using the 
-`<AllowedThirdPartyPackages>`. Wildcard characters are allowed.
-
-``` xml
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <AllowedThirdPartyPackages>
-      SonarAnalyzer.Csharp,
-      MyCompany.*
-    </AllowedThirdPartyPackages>
-  </PropertyGroup>
-
-</Project>
-```
+This rule can detect used licenses in NuGet spec files, but can not be
+considered legal advice, nor is this documentation.


### PR DESCRIPTION
As pointed out by @CptWesley, the most important indicator if a package is compliant, is the license of the package we're dealing with. So focus on getting that right first.