### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ released ones. Check the [Release Notes](https://www.nuget.org/packages/DotNetPr
 to understand if the documented feature you want to use has been released.
 
 ## Purpose
-We consider all files - so not only those who are compiled - in a project part
+We consider all files in a project - so not only those who are compiled - part
 of the codebase. We strongly believe that all files should be easy to read,
 maintain, or to adjust. Our analyzers help with that. They spot noise, bugs,
 inconsistencies, incorrect formatting, and misusage.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ of the codebase. We strongly believe that all files should be easy to read,
 maintain, or to adjust. Our analyzers help with that. They spot noise, bugs,
 inconsistencies, incorrect formatting, and misusage.
 
-All rules come with a clear explaination on why the spotted issue is a bad
+All rules come with a clear explanation on why the spotted issue is a bad
 practice, and how the code should be adjusted. We hope, that as a result,
 developers using our analyzers also learn a thing while worknig with them.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,18 @@ The documentation reflects the current repository state of the features, not the
 released ones. Check the [Release Notes](https://www.nuget.org/packages/DotNetProjectFile.Analyzers#releasenotes-body-tab)
 to understand if the documented feature you want to use has been released.
 
+## Purpose
+We consider all files - so not only those who are compiled - in a project part
+of the codebase. We strongly believe that all files should be easy to read,
+maintain, or to adjust. Our analyzers help with that. They spot noise, bugs,
+inconsitancies, mallformatting, and misusage.
+
+All rules come with a clear explaination on why the spotted issue is a bad
+practice, and how the code should be adjusted. We hope, that as a result,
+developers using our analyzers also learn a thing while worknig with them.
+
 ## Installation
-[![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/v/DotNetProjectFile.Analyzers)![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/dt/DotNetProjectFile.Analyzers)](https://www.nuget.org/packages/DotNetProjectFile.Analyzers/)
+[![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/v/DotNetProjectFile.Analyzers)![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/dt/DotNetProjectFile.Analyzers)](https://www.nuget.org/packages/DotNetProjectFile.Analyzers)
 
 To use the analyzers, you must include the analyzer package in your project file:
 ``` xml
@@ -184,34 +194,6 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 ## .editorconfig
 * [**Proj4050** Header must be a GLOB](rules/Proj4050.md)
 * [**Proj4051** Use equals sign for key-value assignments](rules/Proj4051.md)
-
-## Additional files
-To fully benefit from these analyzers it is recommended to add the project file
-(and imported projects/props) as additional files.
-
-To add a project file:
-
-``` xml
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <AdditionalFiles Include="*.??proj" Visible="false" />
-  </ItemGroup>
-
-</Project>
-```
-
-To add a props file:
-
-``` xml
-<Project>
-
-  <ItemGroup>
-    <AdditionalFiles Include="../props/{file_name}" Link="Properties/{file_name}" />
-  </ItemGroup>
-
-</Project>
-```
 
 ## Sonar integration
 By default, results by .NET project file analyzers are not added to Sonar's reporting. Read [here](general/sonar-integration.md) how to configure this correctly.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ to understand if the documented feature you want to use has been released.
 We consider all files - so not only those who are compiled - in a project part
 of the codebase. We strongly believe that all files should be easy to read,
 maintain, or to adjust. Our analyzers help with that. They spot noise, bugs,
-inconsitancies, mallformatting, and misusage.
+inconsistencies, incorrect formatting, and misusage.
 
 All rules come with a clear explaination on why the spotted issue is a bad
 practice, and how the code should be adjusted. We hope, that as a result,

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ inconsistencies, incorrect formatting, and misusage.
 
 All rules come with a clear explanation on why the spotted issue is a bad
 practice, and how the code should be adjusted. We hope, that as a result,
-developers using our analyzers also learn a thing while worknig with them.
+developers using our analyzers also learn a thing while working with them.
 
 ## Installation
 [![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/v/DotNetProjectFile.Analyzers)![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/dt/DotNetProjectFile.Analyzers)](https://www.nuget.org/packages/DotNetProjectFile.Analyzers)

--- a/general/sdk.md
+++ b/general/sdk.md
@@ -11,7 +11,7 @@ providing both a custom `.props` and a `.targets` MS Build file.
 
 ## .net.csproj
 So how does it work? At the root level of your solution (most likely the
-directory conting the [Git](https://en.wikipedia.org/wiki/Git) repo), you
+directory containing the [Git](https://en.wikipedia.org/wiki/Git) repo), you
 create a C# Project file with the name `.net.csproj`.
 
 ``` xml

--- a/general/sdk.md
+++ b/general/sdk.md
@@ -3,6 +3,7 @@ nav_order: 2
 ---
 
 # .NET Project File Analyzers SDK
+[![DotNetProjectFile.Analyzers.Sdk](https://img.shields.io/nuget/v/DotNetProjectFile.Analyzers.Sdk)![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/dt/DotNetProjectFile.Analyzers.Sdk)](https://www.nuget.org/packages/DotNetProjectFile.Analyzers.Sdk)
 .NET Project File Analyzers ships with its own SDK. This allows files shared by
 multiple projects to be analyzed. It applies a *trick* also used by the
 [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk);
@@ -11,13 +12,13 @@ providing both a custom `.props` and a `.targets` MS Build file.
 ## .net.csproj
 So how does it work? At the root level of your solution (most likely the
 directory conting the [Git](https://en.wikipedia.org/wiki/Git) repo), you
- create a C# Project file with the name `.net.csproj`.
+create a C# Project file with the name `.net.csproj`.
 
 ``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rules/Proj0004.md
+++ b/rules/Proj0004.md
@@ -16,7 +16,7 @@ More information: https://learn.microsoft.com/en-us/nuget/concepts/auditing-pack
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-	<NuGetAudit>false</NuGetAudit>
+    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
 </Project>

--- a/rules/Proj0007.md
+++ b/rules/Proj0007.md
@@ -29,7 +29,7 @@ Empty nodes only add noise, as they contain no information.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetProjectFile.Analyzers" Version="* PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />	
+    <PackageReference Include="DotNetProjectFile.Analyzers" Version="* PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 
 </Project>

--- a/rules/Proj0028.md
+++ b/rules/Proj0028.md
@@ -17,7 +17,7 @@ is ignored by this rule.
   
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <GeneratePackageOnBuild  Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
   </PropertyGroup>
   
 </Project>

--- a/rules/Proj0028.md
+++ b/rules/Proj0028.md
@@ -17,7 +17,7 @@ is ignored by this rule.
   
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-	<GeneratePackageOnBuild  Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild  Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
   </PropertyGroup>
   
 </Project>

--- a/rules/Proj0700.md
+++ b/rules/Proj0700.md
@@ -25,7 +25,7 @@ project has no (publically) accessible compilation artifacts.
 
   <ItemGroup>
     <None Include="Code.cs" />
-	<Content Include="Code.cs" />
+    <Content Include="Code.cs" />
 	<AdditionalFiles Include="Code.cs" />
   </ItemGroup>
   

--- a/rules/Proj1102.md
+++ b/rules/Proj1102.md
@@ -20,7 +20,7 @@ preferred over the `coverlet.msbuild`.
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" PrivateAssets="all" />
-	<PackageReference Include="coverlet.msbuild" PrivateAssets="all" />
+    <PackageReference Include="coverlet.msbuild" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/rules/Proj1700.md
+++ b/rules/Proj1700.md
@@ -23,7 +23,7 @@ is supported, as we do not support reading the `.editorconfig` yet.
      </PropertyGroup>
   
   <ItemGroup Label="With tabs">
-				<Compile Include="../common/Code.cs" />
+    			<Compile Include="../common/Code.cs" />
   </ItemGroup>
 
   <ItemGroup><Folder Include="Same line" /></ItemGroup>

--- a/rules/Proj3002.md
+++ b/rules/Proj3002.md
@@ -25,7 +25,7 @@ should be used instead.
     <!-- Reconsider adding this
     <PackageReference Include="DotNetProjectFile.Analyzers" Version="1.5.8" PrivateAssets="all" />
     -->
-	<PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>
@@ -40,7 +40,7 @@ should be used instead.
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Since [v1.5.10](https://www.nuget.org/packages/DotNetProjectFile.Analyzers/1.5.10), the files we want to analyze are added as additional files automatically, so referring to in the documentation is not longer needed. I also think that we should try to explain why what using our analyzers bring to a developer, so I gave that a try too.