### PR TITLE
Add statement about how to sort

### DIFF
--- a/rules/Proj0015.md
+++ b/rules/Proj0015.md
@@ -10,6 +10,9 @@ human readable. When ordering the references based on
 other criteria, consider grouping them in separate
 `<ItemGroup>`s.
 
+The rule assumes data sorted based on the `@Include` attribute applying
+`StringComparison.OrdinalIgnoreCase`.
+
 ## Non-compliant
 ``` xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/rules/Proj0016.md
+++ b/rules/Proj0016.md
@@ -10,6 +10,9 @@ human readable. When ordering the references based on
 other criteria, consider grouping them in separate
 `<ItemGroup>`s.
 
+The rule assumes data sorted based on the `@Include` attribute applying
+`StringComparison.OrdinalIgnoreCase`.
+
 ## Non-compliant
 ``` xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/rules/Proj0018.md
+++ b/rules/Proj0018.md
@@ -8,6 +8,9 @@ ancestor: MSBuild
 `<ItemGroup>`. When ordering the imports based on other criteria, consider
 grouping them in separate `<ItemGroup>`s.
 
+The rule assumes data sorted based on the `@Include` attribute applying
+`StringComparison.OrdinalIgnoreCase`.
+
 ## Non-compliant
 ``` xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/rules/Proj0019.md
+++ b/rules/Proj0019.md
@@ -8,6 +8,9 @@ ancestor: MSBuild
 in order to make it more human readable. When ordering the references based on
 other criteria, consider grouping them in separate `<ItemGroup>`s.
 
+The rule assumes data sorted based on the `@Include` attribute applying
+`StringComparison.OrdinalIgnoreCase`.
+
 ## Non-compliant
 ``` xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/rules/Proj2002.md
+++ b/rules/Proj2002.md
@@ -5,7 +5,8 @@ ancestor: Rules
 
 # Proj2002: Sort resource file values alphabetically
 To improve readability, and reduce the number of merge conflicts, the `<data>`
-elements should be sorted based on the `@name` attribute.
+elements should be sorted. The rule assumes data sorted based on the `@name`
+attribute applying `StringComparison.OrdinalIgnoreCase`.
 
 ## Non-compliant
 ``` xml


### PR DESCRIPTION
The rules about sorting now state that `StringComparison.OrdinalIgnoreCase` is applied.

Closes https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/issues/404