### PR TITLE
Proj0039: Treat all warnings as errors is considered a bad practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0038** Fully specify NoWarn rule IDs](rules/Proj0038.md)
 * [**Proj0039** Treat all warnings as errors is considered a bad practice](rules/Proj0039.md)
 
-### Pa9kaging
+### Packaging
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)
 * [**Proj0201** Define the project version explicitly](rules/Proj0201.md)
 * [**Proj0202** Define the project description explicitly](rules/Proj0202.md)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0033** Project reference includes should exist](rules/Proj0033.md)
 * [**Proj0034** Import statement could not be resolved by the analyzer](rules/Proj0034.md)
 * [**Proj0035** Remove deprecated RestoreProjectStyle property](rules/Proj0035.md)
-* [**Proj0036** Remove None when redundant](rules/Pr9j0036.md)
+* [**Proj0036** Remove None when redundant](rules/Proj0036.md)
 * [**Proj0037** Exclude runtime when all assets are private](rules/Proj0037.md)
 * [**Proj0038** Fully specify NoWarn rule IDs](rules/Proj0038.md)
 * [**Proj0039** Treat all warnings as errors is considered a bad practice](rules/Proj0039.md)

--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0033** Project reference includes should exist](rules/Proj0033.md)
 * [**Proj0034** Import statement could not be resolved by the analyzer](rules/Proj0034.md)
 * [**Proj0035** Remove deprecated RestoreProjectStyle property](rules/Proj0035.md)
-* [**Proj0036** Remove None when redundant](rules/Proj0036.md)
+* [**Proj0036** Remove None when redundant](rules/Pr9j0036.md)
 * [**Proj0037** Exclude runtime when all assets are private](rules/Proj0037.md)
 * [**Proj0038** Fully specify NoWarn rule IDs](rules/Proj0038.md)
+* [**Proj0039** Treat all warnings as errors is considered a bad practice](rules/Proj0039.md)
 
-### Packaging
+### Pa9kaging
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)
 * [**Proj0201** Define the project version explicitly](rules/Proj0201.md)
 * [**Proj0202** Define the project description explicitly](rules/Proj0202.md)

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -11,7 +11,7 @@ How tempting this may feel (ideally a solution should not contain any warnings),
 ## 1. We’re not developing in a perfect world
 When a warning pops up, the developer facing it, is supposed to solve the issue. That is why we have static code analysis enabled after all. The fact that this is not happening hints that we do not live in a perfect world. Changing the severity to error for all rules will not make a difference.
 
-A developer that was not willing to resolve a warning is most likely also not willing to resolve an error beyond the bare minimum: that means by suppressing the issue, disabling the rule, or by adjusting the code just to satisfy the rule, none of these resolutions is guaranteed to be an improvement.
+A developer that was not willing to resolve the issue as a warning is most likely also not willing to resolve it as an error beyond the bare minimum: that means by suppressing the issue, disabling the rule, or by adjusting the code just to satisfy the rule. None of these resolutions is guaranteed to be an improvement.
 
 Developers that are not capable to solve a warning (correctly) are still not able to do so once its become an error. If they did find the support to solve it correctly, what would make they would do this now? Or will they come up with the solutions equal to the unwilling developer?
 

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -22,7 +22,7 @@ A specific, but common scenario is when a new version of a package is released, 
 The introduction of new rules (introduced by an existing analyser or by a newly added analyser) will potentially report a lot of issues. They might be valid points, but you don't necessarily want to halt the release of all features until all issues are solved. By (temporarily) disabling such rules, newly added code will not yet benefit from this rule.
 
 ## 4. Warnings are not errors
-It is possible to create static code analysis with an error severity. The reason that this is not done by the maker of the rule is with a reason. Apparently the code is not wrong per se, but you are warned that is beneficial to change the code.
+It is possible to create static code analysis with an error severity. The reason that this is not done by the maker of the rule is with a reason. It might be inefficient, deprecated or unreadable code, but not necessarily wrong.
 
 ## 5. Conflicting IDE extensions
 Some extensions in Visual Studio (like VS Spell Checker or SonarQube IDE) add warnings to the build output as they are de facto analysers. As they are not configured by the solution but by the environment of the developer, those developers can not build the solution.

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -8,7 +8,7 @@ ancestor: MSBuild
 MSBuild can be configured to [threat all warnings as errors]( https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-options/errors-warnings#treatwarningsaserrors).
 How tempting this may feel (ideally a solution should not contain any warnings), there are some objections to consider. Because such a policy might be counterproductive.
 
-## 1. We’re not developing in a perfect world
+## 1. Weâ€™re not developing in a perfect world
 When a warning pops up, the developer facing it, should solve the issue. That why we have static code analysis enabled after all. The fact that this is not happening hints that we do not live in a perfect world. By changing the severity to error for all rules, the world we live in will not change.
 
 A developer that was not willing to resolve a warning is most likely also not willing to resolve an error beyond the bare minimum: that means by suppressing the issue, disabling the rule, or by adjusting the code just to satisfy the rule, none of these resolutions is guaranteed to be an improvement.
@@ -28,7 +28,7 @@ It is possible to create static code analysis with an error severity. The reason
 Some extensions in Visual Studio (like VS Spell Checker or SonarQube IDE) add warnings to the build output as they are de facto analysers. As they are not configured by the solution but by the environment of the developer, those developers can not build the solution.
 
 ## 6. False positives
-Although analyser rule builders – like us – try their best to come up with robust and correct analysers, it turns out that now and then a rule reports a false positive. In such cases it is better to not to have to supress the issue, or to adjust the code just so satisfy the rule, but to file a bug report and wait for an update that fixes the FP.
+Although analyser rule builders â€“ like us â€“ try their best to come up with robust and correct analysers, it turns out that now and then a rule reports a false positive. In such cases it is better to not to have to supress the issue, or to adjust the code just so satisfy the rule, but to file a bug report and wait for an update that fixes the FP.
 
 In the end, warnings are an indication as technical debt, and should be handled a such: with care. Using tools like Qodana and SonarQube can create reports on pull requests to reduce the introduction of new warnings (ideally to zero).
 
@@ -40,7 +40,7 @@ On a regular basis the team working on the project should allocate time to addre
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <TreatWarningsAsErrors>true</ TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -1,0 +1,58 @@
+---
+parent: General
+ancestor: MSBuild
+---
+
+# Proj0039: Treat all warnings as errors is considered a bad practice
+
+MSBuild can be configured to [threat all warnings as errors]( https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-options/errors-warnings#treatwarningsaserrors).
+How tempting this may feel (ideally a solution should not contain any warnings), there are some objections to consider. Because such a policy might be counterproductive.
+
+## 1. We’re not developing in a perfect world
+When a warning pops up, the developer facing it, should solve the issue. That why we have static code analysis enabled after all. The fact that this is not happening hints that we do not live in a perfect world. By changing the severity to error for all rules, the world we live in will not change.
+
+A developer that was not willing to resolve a warning is most likely also not willing to resolve an error beyond the bare minimum: that means by suppressing the issue, disabling the rule, or by adjusting the code just to satisfy the rule, none of these resolutions is guaranteed to be an improvement.
+
+Developers that are not capable to solve a warning (correctly) are still not able to do so once its become an error. If they did find the support to solve it correctly, what would make they would do this now? Or will they come up with the solutions equal to the unwilling developer?
+
+## 2. Deprecated code
+A specific, but common scenario is when a new version of a package is released, suddenly some code has been deprecated. Obviously the code has to be adjusted once, but it is not said that the moment you need the new version of the package is also the moment to refactor all code that relies on this now deprecated code.
+
+## 3. New rules
+The introduction of new rules (both because introduced by an existing analyser or because a new analyser was introduced) will potentially report a lot of issues. They might be valid points, but no reason to halt the release of all features until all issues are solved. By (temporarily) disabling such rules, newly added code will not yet benefit from this rule.
+
+## 4. Warnings are not errors
+It is possible to create static code analysis with an error severity. The reason that this is not done by the maker of the rule is with a reason. Apparently the code is not wrong per se, but you are warned that is beneficial to change the code.
+
+## 5. Conflicting IDE extensions
+Some extensions in Visual Studio (like VS Spell Checker or SonarQube IDE) add warnings to the build output as they are de facto analysers. As they are not configured by the solution but by the environment of the developer, those developers can not build the solution.
+
+## 6. False positives
+Although analyser rule builders – like us – try their best to come up with robust and correct analysers, it turns out that now and then a rule reports a false positive. In such cases it is better to not to have to supress the issue, or to adjust the code just so satisfy the rule, but to file a bug report and wait for an update that fixes the FP.
+
+In the end, warnings are an indication as technical debt, and should be handled a such: with care. Using tools like Qodana and SonarQube can create reports on pull requests to reduce the introduction of new warnings (ideally to zero).
+
+On a regular basis the team working on the project should allocate time to address outstanding issues that should be fixed, or decide that a certain rule is not worth the effort for the project. The goal should be to get as close to zero warnings as possible.
+
+## Non-compliant
+``` xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <TreatWarningsAsErrors>true</ TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>
+```
+
+## Compliant
+``` xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>
+```

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -30,7 +30,7 @@ Some extensions in Visual Studio (like VS Spell Checker or SonarQube IDE) add wa
 ## 6. False positives
 Although analyser rule builders – like us – try their best to come up with robust and correct analysers, it turns out that now and then a rule reports a false positive. In such cases it is better to not to have to supress the issue, or to adjust the code just so satisfy the rule, but to file a bug report and wait for an update that fixes the FP.
 
-In the end, warnings are an indication as technical debt, and should be handled a such: with care. Using tools like Qodana and SonarQube can create reports on pull requests to reduce the introduction of new warnings (ideally to zero).
+In the end, warnings are an indication of technical debt, and should be handled a such: with care. Using tools like Qodana and SonarQube can create reports on pull requests to reduce the introduction of new warnings (ideally to zero).
 
 On a regular basis the team working on the project should allocate time to address outstanding issues that should be fixed, or decide that a certain rule is not worth the effort for the project. The goal should be to get as close to zero warnings as possible.
 

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -5,7 +5,7 @@ ancestor: MSBuild
 
 # Proj0039: Treat all warnings as errors is considered a bad practice
 
-MSBuild can be configured to [threat all warnings as errors]( https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-options/errors-warnings#treatwarningsaserrors).
+MSBuild can be configured to [treat all warnings as errors](https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-options/errors-warnings#treatwarningsaserrors).
 How tempting this may feel (ideally a solution should not contain any warnings), there are some objections to consider. Because such a policy might be counterproductive.
 
 ## 1. We’re not developing in a perfect world

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -32,7 +32,7 @@ Although analyser rule builders – like us – try their best to come up with r
 
 In the end, warnings are an indication of technical debt, and should be handled a such: with care. Using tools like Qodana and SonarQube can create reports on pull requests to reduce the introduction of new warnings (ideally to zero).
 
-On a regular basis the team working on the project should allocate time to address outstanding issues that should be fixed, or decide that a certain rule is not worth the effort for the project. The goal should be to get as close to zero warnings as possible.
+On a regular basis, the team working on the project should allocate time to address outstanding issues that should be fixed, or decide that a certain rule is not worth the effort for the project. The goal should be to get as close to zero warnings as possible.
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -13,7 +13,7 @@ When a warning pops up, the developer facing it, is supposed to solve the issue.
 
 A developer that was not willing to resolve the issue as a warning is most likely also not willing to resolve it as an error beyond the bare minimum: that means by suppressing the issue, disabling the rule, or by adjusting the code just to satisfy the rule. None of these resolutions is guaranteed to be an improvement.
 
-Developers that are not capable to solve a warning (correctly) are still not able to do so once its become an error. If they did find the support to solve it correctly, what would make they would do this now? Or will they come up with the solutions equal to the unwilling developer?
+Developers that are not capable to solve a warning (correctly) are still not able to do so once it becomes an error. If they did find the support to solve it correctly, what would make they would do this now? Or will they come up with the solutions equal to the unwilling developer?
 
 ## 2. Deprecated code
 A specific, but common scenario is when a new version of a package is released, suddenly some code has been deprecated. Obviously the code has to be adjusted once, but it is not said that the moment you need the new version of the package is also the moment to refactor all code that relies on this now deprecated code.

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -9,7 +9,7 @@ MSBuild can be configured to [treat all warnings as errors](https://learn.micros
 How tempting this may feel (ideally a solution should not contain any warnings), there are some objections to consider. Because such a policy might be counterproductive.
 
 ## 1. We’re not developing in a perfect world
-When a warning pops up, the developer facing it, should solve the issue. That why we have static code analysis enabled after all. The fact that this is not happening hints that we do not live in a perfect world. By changing the severity to error for all rules, the world we live in will not change.
+When a warning pops up, the developer facing it, is supposed to solve the issue. That is why we have static code analysis enabled after all. The fact that this is not happening hints that we do not live in a perfect world. Changing the severity to error for all rules will not make a difference.
 
 A developer that was not willing to resolve a warning is most likely also not willing to resolve an error beyond the bare minimum: that means by suppressing the issue, disabling the rule, or by adjusting the code just to satisfy the rule, none of these resolutions is guaranteed to be an improvement.
 

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -28,7 +28,7 @@ It is possible to create static code analysis with an error severity. The reason
 Some extensions in Visual Studio (like VS Spell Checker or SonarQube IDE) add warnings to the build output as they are de facto analysers. As they are not configured by the solution but by the environment of the developer, those developers can not build the solution.
 
 ## 6. False positives
-Although analyser rule builders – like us – try their best to come up with robust and correct analysers, it turns out that now and then a rule reports a false positive. In such cases it is better to not to have to supress the issue, or to adjust the code just so satisfy the rule, but to file a bug report and wait for an update that fixes the FP.
+Although analyser rule builders - like us - try their best to come up with robust and correct analysers, it turns out that now and then a rule reports a false positive. In such cases it is better to not to have to supress the issue, or to adjust the code just so satisfy the rule, but to file a bug report and wait for an update that fixes the FP.
 
 In the end, warnings are an indication of technical debt, and should be handled a such: with care. Using tools like Qodana and SonarQube can create reports on pull requests to reduce the introduction of new warnings (ideally to zero).
 

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -28,7 +28,7 @@ It is possible to create static code analysis with an error severity. The reason
 Some extensions in Visual Studio (like VS Spell Checker or SonarQube IDE) add warnings to the build output as they are de facto analysers. As they are not configured by the solution but by the environment of the developer, those developers can not build the solution.
 
 ## 6. False positives
-Although analyser rule builders - like us - try their best to come up with robust and correct analysers, it turns out that now and then a rule reports a false positive. In such cases it is better to not to have to supress the issue, or to adjust the code just so satisfy the rule, but to file a bug report and wait for an update that fixes the FP.
+Although analyser rule builders - like us - try their best to come up with robust and correct analysers, it turns out that now and then a rule reports a false positive. In such cases it is better to not suppress the issue, or adjust the code just to satisfy the rule, but to file a bug report and wait for an update that fixes the FP.
 
 In the end, warnings are an indication of technical debt, and should be handled a such: with care. Using tools like Qodana and SonarQube can create reports on pull requests to reduce the introduction of new warnings (ideally to zero).
 

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -16,7 +16,7 @@ A developer that was not willing to resolve the issue as a warning is most likel
 Developers that are not capable to solve a warning (correctly) are still not able to do so once it becomes an error. If they did find the support to solve it correctly, what would make they would do this now? Or will they come up with the solutions equal to the unwilling developer?
 
 ## 2. Deprecated code
-A specific, but common scenario is when a new version of a package is released, suddenly some code has been deprecated. Obviously the code has to be adjusted once, but it is not said that the moment you need the new version of the package is also the moment to refactor all code that relies on this now deprecated code.
+A specific, but common scenario is when a new version of a package is released, suddenly some code has been deprecated. Obviously the code has to be adjusted at some point, but it is not always the case that the moment you need the new version of the package, is also the moment to refactor all code that relies on this now deprecated code.
 
 ## 3. New rules
 The introduction of new rules (introduced by an existing analyser or by a newly added analyser) will potentially report a lot of issues. They might be valid points, but you don't necessarily want to halt the release of all features until all issues are solved. By (temporarily) disabling such rules, newly added code will not yet benefit from this rule.

--- a/rules/Proj0039.md
+++ b/rules/Proj0039.md
@@ -19,7 +19,7 @@ Developers that are not capable to solve a warning (correctly) are still not abl
 A specific, but common scenario is when a new version of a package is released, suddenly some code has been deprecated. Obviously the code has to be adjusted once, but it is not said that the moment you need the new version of the package is also the moment to refactor all code that relies on this now deprecated code.
 
 ## 3. New rules
-The introduction of new rules (both because introduced by an existing analyser or because a new analyser was introduced) will potentially report a lot of issues. They might be valid points, but no reason to halt the release of all features until all issues are solved. By (temporarily) disabling such rules, newly added code will not yet benefit from this rule.
+The introduction of new rules (introduced by an existing analyser or by a newly added analyser) will potentially report a lot of issues. They might be valid points, but you don't necessarily want to halt the release of all features until all issues are solved. By (temporarily) disabling such rules, newly added code will not yet benefit from this rule.
 
 ## 4. Warnings are not errors
 It is possible to create static code analysis with an error severity. The reason that this is not done by the maker of the rule is with a reason. Apparently the code is not wrong per se, but you are warned that is beneficial to change the code.


### PR DESCRIPTION
I'm aware that this rule is opinionated, and I'm intending to release this with a severity info, instead of a warning. I'm also aware that this is by far the longest rule description, and is written more as a blog. Tips on how to improve that are (also) welcomed.