### PR TITLE
Advise the use of .globalconfig over .editorconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0022** Build action includes should exist](rules/Proj0022.md)
 * [**Proj0023** Use forward slashes in paths](rules/Proj0023.md)
 * [**Proj0024** Order package versions alphabetically](rules/Proj0024.md)
-* [**Proj0025** Migrate from ruleset file to .editorconfig file](rules/Proj0025.md)
+* [**Proj0025** Migrate from ruleset file to .globalconfig file](rules/Proj0025.md)
 * [**Proj0026** Remove IncludeAssets when redundant](rules/Proj0026.md)
 * [**Proj0027** Override &lt;TargetFrameworks&gt; with &lt;TargetFrameworks&gt;](rules/Proj0027.md)
 * [**Proj0028** Define conditions on level 1](rules/Proj0028.md)

--- a/rules/Proj0025.md
+++ b/rules/Proj0025.md
@@ -3,14 +3,16 @@ parent: General
 ancestor: MSBuild
 ---
 
-# Proj0025: Migrate from ruleset file to .editorconfig file
-Microsoft deprecated the use of `.ruleset` in favor of `.editorconfig` files.
+# Proj0025: Migrate from ruleset file to .globalconfig file
+Microsoft deprecated the use of `.ruleset` in favor of `.globalconfig` files.
 In Visual Studio by clicking the file, it will automatically pop up a dialog to
 convert the ruleset.
 
 Alternatively, you can download the converter yourself from [NuGet](https://www.nuget.org/packages/Microsoft.CodeAnalysis.RulesetToEditorconfigConverter).
+For more info: [learn.microsoft.com](https://learn.microsoft.com/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2022#convert-an-existing-ruleset-file-to-editorconfig-file)
 
-For more info: [learn.microsoft.com])https://learn.microsoft.com/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2022#convert-an-existing-ruleset-file-to-editorconfig-file)
+Note the difference between `.editorconfig` and `.globalconfig` here. It is
+advised to put analyzer configuration in the `[.globalconfig` file](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig).
 
 ## Non-compliant
 ``` xml
@@ -25,6 +27,26 @@ For more info: [learn.microsoft.com])https://learn.microsoft.com/visualstudio/co
 ```
 
 ## Compliant
+``` xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+    
+</Project>
+```
+
+*.globalconfig*
+``` ini
+is_global = true
+
+dotnet_diagnostic.CA1000.severity = warning
+...
+```
+
+or with an explicit import of a config file:
+
 ``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 


### PR DESCRIPTION
When converting the rulset fies we should advise to convert to `.globalconfig` over `.editorconfig`.