### PR TITLE
Make MS URL's language agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![.NET project file analyzers logo](design/logo_128x128.png)
 # .NET project file analyzers
 is a [NuGet](https://www.nuget.org/packages/DotNetProjectFile.Analyzers/) package
-containing [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
-(static code) [analyzers](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.diagnostics.diagnosticanalyzer)
+containing [Roslyn](https://docs.microsoft.com/dotnet/csharp/roslyn-sdk/)
+(static code) [analyzers](https://docs.microsoft.com/dotnet/api/microsoft.codeanalysis.diagnostics.diagnosticanalyzer)
 that report issues on .NET project files.
 
 The documentation reflects the current repository state of the features, not the

--- a/general/configuration.md
+++ b/general/configuration.md
@@ -13,7 +13,7 @@ file. Unfortunately, changing the severity (and other configuration) of rules
 in the `.editorconfig` is [**NOT** supported by MS Build](https://github.com/dotnet/roslyn/issues/37876).
 
 ## Global analyzer config
-It is also possible to configure rules using a [Global AnalyzerConfig](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig)
+It is also possible to configure rules using a [Global AnalyzerConfig](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig)
 `.globalconfig` file located in the same directory as the project file or in
 one of its (grand)parent directories. The following `.globalconfig` file will
 disable rule `Proj0010` and raise `Proj0011` to error level:

--- a/rules/Proj0017.md
+++ b/rules/Proj0017.md
@@ -6,7 +6,7 @@ ancestor: MSBuild
 # Proj0017: Can't create alias for static using directive
 `<Using>` nodes can not be both marked as `Static` and be an `Alias`.
 For more info
-[see](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/using-directive-errors?f1url=%3FappId%3Droslyn%26k%3Dk(CS8085)#restrictions-on-using-aliases).
+[see](https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-messages/using-directive-errors?f1url=%3FappId%3Droslyn%26k%3Dk(CS8085)#restrictions-on-using-aliases).
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0032.md
+++ b/rules/Proj0032.md
@@ -5,7 +5,7 @@ ancestor: MSBuild
 
 # Proj0032: Migrate away from BinaryFormatter
 Starting with .NET 9, Microsoft no longer includes an implementation of
-`BinaryFormatter` in the runtime (it has [been deprecated](https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/5.0/binaryformatter-serialization-obsolete)
+`BinaryFormatter` in the runtime (it has [been deprecated](https://learn.microsoft.com/dotnet/core/compatibility/serialization/5.0/binaryformatter-serialization-obsolete)
 with the release of .NET 5). The APIs are still present, but their
 implementation always throws an exception, regardless of project type.
 
@@ -14,7 +14,7 @@ to use `BinaryFormatter` with .NET 9, as is explained in [this blog post](https:
 
 Due to the fact that Microsoft discourages the usage as strongly as they
 can, this rule reports violations for all target frameworks, and
-also when used in combination with [System.Runtime.Serialization.Formatters](https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-migration-guide/compatibility-package).
+also when used in combination with [System.Runtime.Serialization.Formatters](https://learn.microsoft.com/dotnet/standard/serialization/binaryformatter-migration-guide/compatibility-package).
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0042.md
+++ b/rules/Proj0042.md
@@ -4,7 +4,7 @@ ancestor: MSBuild
 ---
 
 # Proj0042: Enable &lt;ContinuousIntegrationBuild&gt; when running in CI pipeline
-Setting `ContinuousIntegrationBuild` to `true` [ensures (file) paths are normalized](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild)
+Setting `ContinuousIntegrationBuild` to `true` [ensures (file) paths are normalized](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild)
 and furthermore can help other external tools with detecting whether a build
 is being performed in a continuous integration (CI) pipeline, such as for [Proj0044](./Proj0044.md).
 

--- a/rules/Proj0240.md
+++ b/rules/Proj0240.md
@@ -9,7 +9,7 @@ of the API surface of your package, it is advised
 to enable package validation by defining the
 `<EnablePackageValidation>` node with value `true`.
 
-More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview).
+More information can be found [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview).
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0241.md
+++ b/rules/Proj0241.md
@@ -10,7 +10,7 @@ to enable package baseline validation by defining the
 `<PackageValidationBaselineVersion>` node with the version
 of the previous stable release.
 
-More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/baseline-version-validator).
+More information can be found [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/baseline-version-validator).
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0244.md
+++ b/rules/Proj0244.md
@@ -7,8 +7,8 @@ ancestor: Rules
 In order for code documentation to be visible for package consumers
 it is important that the documentation is generated.
 This can either be done by using the
-[`<GenerateDocumentationFile>`](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile)
-or the [`<DocumentationFile>`](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#documentationfile)
+[`<GenerateDocumentationFile>`](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile)
+or the [`<DocumentationFile>`](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#documentationfile)
 tags.
 
 This requires _either_ `<GenerateDocumentationFile>` to be set to `true`,
@@ -79,5 +79,5 @@ Or:
 ```
 
 ## More info
-1. [learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile)
-2. [learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#documentationfile)
+1. [learn.microsoft.com](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile)
+2. [learn.microsoft.com](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#documentationfile)

--- a/rules/Proj0247.md
+++ b/rules/Proj0247.md
@@ -8,7 +8,7 @@ When ensuring backwards compatibility of the API surface
 of your package, it is advised to do this in strict mode.
 This helps preventing any unintentional API changes.
 
-More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview), [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/baseline-version-validator) and [here](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#enablestrictmodeforbaselinevalidation).
+More information can be found [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview), [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/baseline-version-validator) and [here](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#enablestrictmodeforbaselinevalidation).
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0248.md
+++ b/rules/Proj0248.md
@@ -10,7 +10,7 @@ compatibility validation.
 
 Note that the default value is `true` and can therefore be omitted.
 
-More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview), [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/compatible-framework-validator) and [here](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#enablestrictmodeforcompatibletfms).
+More information can be found [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview), [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/compatible-framework-validator) and [here](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#enablestrictmodeforcompatibletfms).
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0249.md
+++ b/rules/Proj0249.md
@@ -8,7 +8,7 @@ When building your package for multiple target
 frameworks it is advised to enable the strict
 mode of the framework compatibility validation.
 
-More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview), [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/compatible-framework-in-package-validator) and [here](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#enablestrictmodeforcompatibleframeworksinpackage).
+More information can be found [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview), [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/compatible-framework-in-package-validator) and [here](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#enablestrictmodeforcompatibleframeworksinpackage).
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0250.md
+++ b/rules/Proj0250.md
@@ -4,12 +4,12 @@ ancestor: Rules
 ---
 
 # Proj0250: Generate API compatibility suppression file
-When [package validation](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview) is enabled, it is required to
-provide a [suppression file](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/diagnostic-ids#how-to-suppress) for all differences that
+When [package validation](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview) is enabled, it is required to
+provide a [suppression file](https://learn.microsoft.com/dotnet/fundamentals/apicompat/diagnostic-ids#how-to-suppress) for all differences that
 occur in the API:
-- [Changes between different package versions](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/baseline-version-validator)
-- [Differences between different runtimes (e.g. windows vs unix)](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/compatible-framework-validator)
-- [Differences between different target frameworks (e.g. netstandard2.0 vs net8.0)](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/compatible-framework-in-package-validator)
+- [Changes between different package versions](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/baseline-version-validator)
+- [Differences between different runtimes (e.g. windows vs unix)](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/compatible-framework-validator)
+- [Differences between different target frameworks (e.g. netstandard2.0 vs net8.0)](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/compatible-framework-in-package-validator)
 
 This suppression file can be created manually, or automatically generated
 by enabling the `GenerateCompatibilitySuppressionFile` property. It is advised
@@ -20,7 +20,7 @@ Additionally, it is advised to keep changes to the generated file tracked in
 your version control system to ensure any API changes are explicitly included
 in code reviews.
 
-More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview), [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/diagnostic-ids#how-to-suppress) and [here](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#apicompatgeneratesuppressionfile).
+More information can be found [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview), [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/diagnostic-ids#how-to-suppress) and [here](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#apicompatgeneratesuppressionfile).
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0251.md
+++ b/rules/Proj0251.md
@@ -4,10 +4,10 @@ ancestor: Rules
 ---
 
 # Proj0251: Enable API compatibility attribute checks
-When [package validation](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview)
+When [package validation](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview)
 is enabled, it is advised to opt-in to the strict attribute compatibility checks.
 
-More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview) and [here](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#apicompatenableruleattributesmustmatch).
+More information can be found [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview) and [here](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#apicompatenableruleattributesmustmatch).
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0252.md
+++ b/rules/Proj0252.md
@@ -4,14 +4,14 @@ ancestor: Rules
 ---
 
 # Proj0252: Enable API compatibility parameter name checks
-When [package validation](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview)
+When [package validation](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview)
 is enabled, it is advised to opt-in to the strict parameter name compatibility checks.
 While renaming parameters does not directly break runtime compatibility, it can break
 source compatibility when a consuming application uses
-[explicit parameter names](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments#named-arguments)
+[explicit parameter names](https://learn.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments#named-arguments)
 when calling one of your methods.
 
-More information can be found [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview), [here](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#apicompatenablerulecannotchangeparametername) and [here](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments#named-arguments).
+More information can be found [here](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview), [here](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#apicompatenablerulecannotchangeparametername) and [here](https://learn.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments#named-arguments).
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0501.md
+++ b/rules/Proj0501.md
@@ -9,7 +9,7 @@ and/or your company explicitly agree with the legally binding conditions of the
 license and the copyright of the owner of the package.
 
 In the past, Microsoft decided to communicate the license of a package via a
-[`<licenseUrl>`](https://learn.microsoft.com/en-us/nuget/reference/nuspec#licenseurl).
+[`<licenseUrl>`](https://learn.microsoft.com/nuget/reference/nuspec#licenseurl).
 This feature has been deprecated since 2018. You are advised to use
 either a newer version of the package (with a resolveble license) or to contact
 the creator of the package and ask for an update.

--- a/rules/Proj0808.md
+++ b/rules/Proj0808.md
@@ -6,7 +6,7 @@ ancestor: Rules
 # Proj0808: Define global package reference only in Directory.Packages.props
 When using [Central Package Management](Proj0800.md) the central `Directory.Packages.props`
 it is possible to define a package reference globally with the use of
-[`<GlobalPackageReference>`](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management#global-package-references).
+[`<GlobalPackageReference>`](https://learn.microsoft.com/nuget/consume-packages/central-package-management#global-package-references).
 These references should only be in your `Directory.Packages.props`.
 
 ## Compliant

--- a/rules/Proj0809.md
+++ b/rules/Proj0809.md
@@ -6,7 +6,7 @@ ancestor: Rules
 # Proj0809: Global package references are meant for private assets only
 When using [Central Package Management](Proj0800.md) the central `Directory.Packages.props`
 it is possible to define package reference globally with the use of
-[`<GlobalPackageReference>`](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management#global-package-references).
+[`<GlobalPackageReference>`](https://learn.microsoft.com/nuget/consume-packages/central-package-management#global-package-references).
 This should only be used for references that should be handled as a private asset.
 
 ## Non-compliant

--- a/rules/Proj2003.md
+++ b/rules/Proj2003.md
@@ -7,4 +7,4 @@ ancestor: Rules
 To ensure that localized values can be resolved, a localized resource file
 must have a culture invariant alternative.
 
-See: [https://learn.microsoft.com/en-us/dotnet/core/extensions/localization](https://learn.microsoft.com/en-us/dotnet/core/extensions/localization)
+See: [https://learn.microsoft.com/dotnet/core/extensions/localization](https://learn.microsoft.com/dotnet/core/extensions/localization)

--- a/rules/Proj2004.md
+++ b/rules/Proj2004.md
@@ -7,4 +7,4 @@ ancestor: Rules
 To ensure that localized values can be resolved, a localized value must have a
 culture invariant alternative.
 
-See: [https://learn.microsoft.com/en-us/dotnet/core/extensions/localization](https://learn.microsoft.com/en-us/dotnet/core/extensions/localization)
+See: [https://learn.microsoft.com/dotnet/core/extensions/localization](https://learn.microsoft.com/dotnet/core/extensions/localization)


### PR DESCRIPTION
Microsoft provides its documentation in multiple languages. By omitting the language ('/en-us/') it is up to the visitors preference which language Microsoft serves them, hence the changes.