### PR TITLE
Add ThirdPartyLicense node to documentation

### DIFF
--- a/rules/Proj0807.md
+++ b/rules/Proj0807.md
@@ -31,6 +31,10 @@ work otherwise, it is counter-intuitive and recipe for disaster.
   </ItemGroup>
   
   <ItemGroup>
+    <ThirdPartyLicense Include="SonarAnalyzer.CSharp" Hash="IBM9yngU7omFyJOMSFSy0w" />
+  </ItemGroup>
+    
+  <ItemGroup>
     <AdditionalFiles Include="Directory.Packages.props" Link="Properties/Directory.Packages.props" />
     <AdditionalFiles Include="*.ts" />
   </ItemGroup>
@@ -55,6 +59,10 @@ work otherwise, it is counter-intuitive and recipe for disaster.
     
   <ItemGroup>
     <GlobalPackageReference Include="DotNetProjectFile.Analyzers" Vesion="1.5.8" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ThirdPartyLicense Include="SonarAnalyzer.CSharp" Hash="IBM9yngU7omFyJOMSFSy0w" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Updated documentation to align with https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/447.