### PR TITLE
Proj0218: Symbol package format snupkg requires debug type portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0215** Provide a compliant NuGet package icon](rules/Proj0215.md)
 * [**Proj0216** Define the product name explicitly](rules/Proj0216.md)
 * [**Proj0217** Define requiring license acceptance explicitly](rules/Proj0217.md)
+* [**Proj0218** Symbol package format snupkg requires debug type portable](rules/Proj0218.md)
 * [**Proj0240** Enable package validation](rules/Proj0240.md)
 * [**Proj0241** Enable package baseline validation](rules/Proj0241.md)
 * [**Proj0242** Generate NuGet packages conditionally](rules/Proj0242.md)

--- a/rules/Proj0218.md
+++ b/rules/Proj0218.md
@@ -1,0 +1,37 @@
+---
+parent: Packaging
+ancestor: Rules
+---
+
+# Proj0218: Symbol package format snupkg requires debug type portable
+[When creating symbols `.snupkg` package](https://learn.microsoft.com/nuget/create-packages/symbol-packages-snupkg),
+having `<DebugType>` set to `full` or `pdbonly` result in an invalid `.snupkg`
+(or at least one that the official nuget symbol server can't process). Meanwhile
+`<DebugType>` value `embedded` results in the symbols being included in the
+ regular binaries, defeating the purpose of the seperate `.snupkg`.
+
+## Non-compliant
+``` xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+</Project>
+```
+
+## Compliant
+``` xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+</Project>
+```

--- a/rules/Proj0218.md
+++ b/rules/Proj0218.md
@@ -6,7 +6,7 @@ ancestor: Rules
 # Proj0218: Symbol package format snupkg requires debug type portable
 [When creating symbols `.snupkg` package](https://learn.microsoft.com/nuget/create-packages/symbol-packages-snupkg),
 having `<DebugType>` set to `full` or `pdbonly` results in an invalid `.snupkg`
-(or at least one that the official nuget symbol server can't process). Meanwhile
+(or at least one that the official nuget symbol server can't process). Meanwhile,
 `<DebugType>` value `embedded` results in the symbols being included in the
  regular binaries, defeating the purpose of the separate `.snupkg`.
 

--- a/rules/Proj0218.md
+++ b/rules/Proj0218.md
@@ -8,7 +8,7 @@ ancestor: Rules
 having `<DebugType>` set to `full` or `pdbonly` result in an invalid `.snupkg`
 (or at least one that the official nuget symbol server can't process). Meanwhile
 `<DebugType>` value `embedded` results in the symbols being included in the
- regular binaries, defeating the purpose of the seperate `.snupkg`.
+ regular binaries, defeating the purpose of the separate `.snupkg`.
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0218.md
+++ b/rules/Proj0218.md
@@ -8,7 +8,7 @@ ancestor: Rules
 having `<DebugType>` set to `full` or `pdbonly` results in an invalid `.snupkg`
 (or at least one that the official nuget symbol server can't process). Meanwhile,
 `<DebugType>` value `embedded` results in the symbols being included in the
- regular binaries, defeating the purpose of the separate `.snupkg`.
+ regular binaries, defeating the purpose of the separate `.snupkg` file.
 
 ## Non-compliant
 ``` xml

--- a/rules/Proj0218.md
+++ b/rules/Proj0218.md
@@ -5,7 +5,7 @@ ancestor: Rules
 
 # Proj0218: Symbol package format snupkg requires debug type portable
 [When creating symbols `.snupkg` package](https://learn.microsoft.com/nuget/create-packages/symbol-packages-snupkg),
-having `<DebugType>` set to `full` or `pdbonly` result in an invalid `.snupkg`
+having `<DebugType>` set to `full` or `pdbonly` results in an invalid `.snupkg`
 (or at least one that the official nuget symbol server can't process). Meanwhile
 `<DebugType>` value `embedded` results in the symbols being included in the
  regular binaries, defeating the purpose of the separate `.snupkg`.


### PR DESCRIPTION
Documentation for https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/467