### PR TITLE
Proj0045: Convention-based MSBuild file names should use correct casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0042** Enable &lt;ContinuousIntegrationBuild&gt; when running in CI pipeline](rules/Proj0042.md)
 * [**Proj0043** Use lock files](rules/Proj0043.md)
 * [**Proj0044** Enable &lt;RestoreLockedMode&gt; when &lt;ContinuousIntegrationBuild&gt; is enabled](rules/Proj0044.md)
+* [**Proj0045** Name convention based MSBuild files should have correct casing](rules/Proj0045.md)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0042** Enable &lt;ContinuousIntegrationBuild&gt; when running in CI pipeline](rules/Proj0042.md)
 * [**Proj0043** Use lock files](rules/Proj0043.md)
 * [**Proj0044** Enable &lt;RestoreLockedMode&gt; when &lt;ContinuousIntegrationBuild&gt; is enabled](rules/Proj0044.md)
-* [**Proj0045** Name convention based MSBuild files should have correct casing](rules/Proj0045.md)
+* [**Proj0045** Convention-based MSBuild file names should use correct casin](rules/Proj0045.md)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj0042** Enable &lt;ContinuousIntegrationBuild&gt; when running in CI pipeline](rules/Proj0042.md)
 * [**Proj0043** Use lock files](rules/Proj0043.md)
 * [**Proj0044** Enable &lt;RestoreLockedMode&gt; when &lt;ContinuousIntegrationBuild&gt; is enabled](rules/Proj0044.md)
-* [**Proj0045** Convention-based MSBuild file names should use correct casin](rules/Proj0045.md)
+* [**Proj0045** Convention-based MSBuild file names should use correct casing](rules/Proj0045.md)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)

--- a/rules/Proj0045.md
+++ b/rules/Proj0045.md
@@ -11,7 +11,7 @@ are case-sensitve. This rule will report when the casing of such convention
 based files is off.
 
 ## Compliant
-Files for which the casing is checked.
+Files for which the casing is checked:
 * .editorconfig
 * .globalconfig
 * .net.csproj

--- a/rules/Proj0045.md
+++ b/rules/Proj0045.md
@@ -3,7 +3,7 @@ parent: General
 ancestor: MSBuild
 ---
 
-# Proj0045: Name convention based MSBuild files should have correct casing
+# Proj0045: Convention-based MSBuild file names should use correct casing
 Some MSBuild files have a certain role during the build based on a name
 convention. Although MSBuild is mostely case-insensitive this having different
 casing might cause issues, specially on files systems (Unix for instance) that

--- a/rules/Proj0045.md
+++ b/rules/Proj0045.md
@@ -4,7 +4,7 @@ ancestor: MSBuild
 ---
 
 # Proj0045: Convention-based MSBuild file names should use correct casing
-Some MSBuild files have a certain role during the build based on a name
+Some MSBuild files have a certain role during the build based on a naming
 convention. Although MSBuild is mostely case-insensitive this having different
 casing might cause issues, specially on files systems (Unix for instance) that
 are case-sensitve. This rule will report when the casing of such convention

--- a/rules/Proj0045.md
+++ b/rules/Proj0045.md
@@ -5,8 +5,8 @@ ancestor: MSBuild
 
 # Proj0045: Convention-based MSBuild file names should use correct casing
 Some MSBuild files have a certain role during the build based on a naming
-convention. Although MSBuild is mostely case-insensitive this having different
-casing might cause issues, specially on files systems (Unix for instance) that
+convention. Although MSBuild is mostly case-insensitive, this having different
+casing might cause issues, especially on files systems (Unix for instance) that
 are case-sensitve. This rule will report when the casing of such convention
 based files is off.
 

--- a/rules/Proj0045.md
+++ b/rules/Proj0045.md
@@ -1,0 +1,24 @@
+---
+parent: General
+ancestor: MSBuild
+---
+
+# Proj0045: Name convention based MSBuild files should have correct casing
+Some MSBuild files have a certain role during the build based on a name
+convention. Although MSBuild is mostely case-insensitve this having different
+casing might cause issues, specially on files systems (Unix for instance) that
+are case-sensitve. This rule will report when the casing of such convention
+based files is off.
+
+## Compliant
+Files for which the casing is checked.
+* .editorconfig
+* .globalconfig
+* .net.csproj
+* CompatibilitySuppressions.xml
+* Directory.Build.props
+* Directory.Build.targets
+* Directory.Packages.props
+* global.json
+* NuGet.config
+* packages.lock.json

--- a/rules/Proj0045.md
+++ b/rules/Proj0045.md
@@ -5,7 +5,7 @@ ancestor: MSBuild
 
 # Proj0045: Name convention based MSBuild files should have correct casing
 Some MSBuild files have a certain role during the build based on a name
-convention. Although MSBuild is mostely case-insensitve this having different
+convention. Although MSBuild is mostely case-insensitive this having different
 casing might cause issues, specially on files systems (Unix for instance) that
 are case-sensitve. This rule will report when the casing of such convention
 based files is off.


### PR DESCRIPTION
Documentation for https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/pull/471